### PR TITLE
Fix KPI hint suppression when auto tuning is enabled

### DIFF
--- a/backend/ai_meeting.py
+++ b/backend/ai_meeting.py
@@ -1505,8 +1505,9 @@ class Meeting:
                     rec.update(fb)
                     self.logger.append_control(rec)
                     # 1) 隠しプロンプト
-                    if self.cfg.kpi_auto_prompt and fb.get("hint") and not self.cfg.kpi_auto_tune:
-                         self._ctrl_hint = fb["hint"]; self._ctrl_ttl = 1  # 次ターンだけ
+                    if self.cfg.kpi_auto_prompt and fb.get("hint"):
+                        self._ctrl_hint = fb["hint"]
+                        self._ctrl_ttl = 1  # 次ターンだけ
                     # 2) 自動チューニング
                     if self.cfg.kpi_auto_tune and "tune" in fb:
                         for key,val in fb["tune"].items():


### PR DESCRIPTION
## Summary
- ensure KPI controller hints are stored whenever kpi_auto_prompt is enabled
- remove the condition that blocked hints when KPI auto tuning was active

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d2cc2feac4832cbde67ee3a7192854