### PR TITLE
Configure Vite alias for src imports

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url))
+    }
+  },
   server: {
     proxy: {
       "/logs": { target: "http://localhost:8000", changeOrigin: true }


### PR DESCRIPTION
## Summary
- configure the Vite resolver alias so that `@` points to the src directory for frontend imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cc7f1ef8832c9c6c14efb585d849