### PR TITLE
Update default agent names on home page

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,7 +7,7 @@ export default function Home() {
   const [topic, setTopic] = useState("");
   const [precision, setPrecision] = useState(5);
   const [rounds, setRounds] = useState(4);
-  const [agents, setAgents] = useState("planner worker critic");
+  const [agents, setAgents] = useState("Alice Bob Carol");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -69,8 +69,8 @@ export default function Home() {
         </div>
 
         <label className="label">
-          エージェント（空白区切り）
-          <input className="input" value={agents} onChange={(e) => setAgents(e.target.value)} placeholder="planner worker critic" />
+          参加者名（空白区切り、例: Alice Bob Carol）
+          <input className="input" value={agents} onChange={(e) => setAgents(e.target.value)} placeholder="Alice Bob Carol" />
         </label>
 
         <div className="actions">


### PR DESCRIPTION
## Summary
- update the default agent list on the home page to use generic participant names
- refresh the input label and placeholder to match the new default values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b169209c832c9f8792ff80b1dca4