### PR TITLE
Update default Ollama model to gpt-oss:20b

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     OLLAMA_URL: str = "http://127.0.0.1:11434"
-    DEFAULT_MODEL: str = "llama3"
+    DEFAULT_MODEL: str = "gpt-oss:20b"
+
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- update the backend settings so the default Ollama model is `gpt-oss:20b`
- ensure the settings module ends with a trailing newline for consistent formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d76cfebc832cbc786c85528cea48