### PR TITLE
Add CLI entry point and dependency fallbacks

### DIFF
--- a/backend/ai_meeting/__init__.py
+++ b/backend/ai_meeting/__init__.py
@@ -1,0 +1,5 @@
+"""ai_meetingパッケージの公開API。"""
+
+from .cli import main as cli_main
+
+__all__ = ["cli_main"]

--- a/backend/ai_meeting/__main__.py
+++ b/backend/ai_meeting/__main__.py
@@ -1,0 +1,7 @@
+"""ai_meetingパッケージのCLIエントリポイント。"""
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/ai_meeting/backends.py
+++ b/backend/ai_meeting/backends.py
@@ -1,6 +1,11 @@
 # backend/ai_meeting/backends.py
 from typing import Protocol
-import requests
+
+try:
+    import requests
+except ModuleNotFoundError:  # requests が未インストールでも --help が動作するように遅延対応
+    requests = None  # type: ignore[assignment]
+
 from .models import LLMRequest
 
 class LLMBackend(Protocol):
@@ -27,6 +32,9 @@ class OllamaBackend:
             "options": {"temperature": req.temperature},
             "stream": False,  # 単一JSONに固定 [file:1]
         }  # [file:1]
+
+        if requests is None:  # pragma: no cover - 実行時に明示的に通知する
+            raise RuntimeError("OllamaBackend を利用するには requests をインストールしてください。")
 
         r = requests.post(f"{self.host}/api/chat", json=payload, timeout=120)
         r.raise_for_status()  # [file:1]
@@ -76,6 +84,9 @@ class EchoBackend:
             "options": {"temperature": req.temperature},
             "stream": False,  # ★ これが重要（単一JSONにする）
         }
+        if requests is None:  # pragma: no cover - 実行時に明示的に通知する
+            raise RuntimeError("EchoBackend を利用するには requests をインストールしてください。")
+
         r = requests.post(f"{self.host}/api/chat", json=payload, timeout=120)
         r.raise_for_status()
 

--- a/backend/ai_meeting/cli.py
+++ b/backend/ai_meeting/cli.py
@@ -14,6 +14,7 @@ def main():
     parser.add_argument("--backend", choices=["openai", "ollama", "echo"], default="echo")
     parser.add_argument("--config", help="JSON config path")
     parser.add_argument("--outdir", default=None)
+    parser.add_argument("--agents", nargs="*", help="互換性維持用のダミー引数")
     args = parser.parse_args()
 
     cfg = load_config(args)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,4 +1,24 @@
-from pydantic_settings import BaseSettings
+import os
+
+try:
+    from pydantic_settings import BaseSettings
+except ModuleNotFoundError:  # ランタイム環境に依存せず動作させるためのフォールバック
+    class BaseSettings:
+        """pydantic-settings が無い環境向けの簡易代替。"""
+
+        def __init__(self, **values):
+            for name, default in self._defaults().items():
+                setattr(self, name, os.getenv(name, default))
+            for name, value in values.items():
+                setattr(self, name, value)
+
+        @classmethod
+        def _defaults(cls):
+            return {
+                k: v
+                for k, v in cls.__dict__.items()
+                if k.isupper() and not k.startswith("_")
+            }
 
 class Settings(BaseSettings):
     OLLAMA_URL: str = "http://127.0.0.1:11434"


### PR DESCRIPTION
## Summary
- add a module-level entry point so `python -m backend.ai_meeting` executes the CLI
- export the CLI entry point and accept the legacy `--agents` flag for compatibility
- introduce lightweight fallbacks for optional dependencies so the CLI and FastAPI app run without extra packages

## Testing
- python -m backend.ai_meeting --help
- python - <<'PY'
from backend.app import start_meeting, StartMeetingIn, BackgroundTasks
body = StartMeetingIn(topic="テスト会議", precision=5, rounds=1, backend="openai")
result = start_meeting(body, BackgroundTasks())
print(result)
PY

------
https://chatgpt.com/codex/tasks/task_e_68dbeb4b90d8832c814ac2fbdebc0940