### PR TITLE
Ensure system prompt forwarded to Ollama backend

### DIFF
--- a/backend/ai_meeting/backends.py
+++ b/backend/ai_meeting/backends.py
@@ -26,9 +26,15 @@ class OllamaBackend:
     def generate(self, req: LLMRequest) -> str:
         import json  # [file:1]
 
+        messages = [{"role": "system", "content": req.system}]
+        for idx, message in enumerate(req.messages):
+            if "role" not in message:
+                raise ValueError(f"messages[{idx}] に 'role' キーが必要です: {message}")
+            messages.append(message)
+
         payload = {
             "model": self.model,
-            "messages": req.messages,
+            "messages": messages,
             "options": {"temperature": req.temperature},
             "stream": False,  # 単一JSONに固定 [file:1]
         }  # [file:1]


### PR DESCRIPTION
## Summary
- prepend the system prompt as a system role entry when sending chat payloads to Ollama
- validate that every request message includes an explicit role before contacting the Ollama API

## Testing
- python - <<'PY'
import backend.ai_meeting.backends as backends
from backend.ai_meeting.models import LLMRequest
from types import SimpleNamespace
from unittest.mock import Mock

mock_post = Mock()
mock_response = Mock()
mock_response.json.return_value = {"message": {"content": "dummy"}}
mock_response.raise_for_status.return_value = None
mock_post.return_value = mock_response
backends.requests = SimpleNamespace(post=mock_post)

backend = backends.OllamaBackend(model="test-model")
req = LLMRequest(system="sys prompt", messages=[{"role": "user", "content": "hello"}])
result = backend.generate(req)
print("result:", result)
print("payload:", mock_post.call_args.kwargs["json"])

try:
    bad_req = LLMRequest(system="s", messages=[{"content": "oops"}])
    backend.generate(bad_req)
except ValueError as e:
    print("error:", e)
PY

------
https://chatgpt.com/codex/tasks/task_e_68dbf4e2f3d8832ca526d2428922f56c