### PR TITLE
Add backend.ai_meeting package wrapper and migration plan

### DIFF
--- a/backend/ai_meeting/__init__.py
+++ b/backend/ai_meeting/__init__.py
@@ -1,0 +1,48 @@
+"""`backend.ai_meeting` パッケージの暫定エントリーポイント。
+
+旧 `backend/ai_meeting.py` モジュールをそのまま利用しつつ、
+段階的にパッケージ構成へ移行できるようにする。
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Optional, TypeVar, cast
+
+__all__ = ["load_legacy_module", "get_main"]
+
+TFunc = TypeVar("TFunc", bound=Callable[..., object])
+
+
+def load_legacy_module() -> ModuleType:
+    """旧 `backend/ai_meeting.py` をモジュールとして読み込む。
+
+    Python の import 解決順はパッケージを優先するため、
+    本パッケージ作成後は `import backend.ai_meeting` が
+    自身を指してしまう。この関数ではファイルパスを指定して
+    旧実装を読み込み、従来の関数を利用できるようにする。
+    """
+
+    package_dir = Path(__file__).resolve().parent
+    legacy_path = package_dir.parent / f"{package_dir.name}.py"
+
+    spec = importlib.util.spec_from_file_location(
+        "backend.ai_meeting_legacy", legacy_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"旧モジュールを読み込めませんでした: {legacy_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def get_main() -> Callable[..., object]:
+    """旧モジュールの `main()` を取得する。"""
+
+    module = load_legacy_module()
+    main_attr: Optional[object] = getattr(module, "main", None)
+    if not callable(main_attr):
+        raise AttributeError("旧モジュールに main() が見つかりません。")
+    return cast(TFunc, main_attr)

--- a/backend/ai_meeting/__main__.py
+++ b/backend/ai_meeting/__main__.py
@@ -1,0 +1,15 @@
+"""`python -m backend.ai_meeting` 用の暫定ラッパー。"""
+from __future__ import annotations
+
+from . import get_main
+
+
+def main() -> None:
+    """旧 `main()` を呼び出す。"""
+
+    legacy_main = get_main()
+    legacy_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/backend_ai_meeting_refactor.md
+++ b/docs/backend_ai_meeting_refactor.md
@@ -1,0 +1,68 @@
+# `backend.ai_meeting` パッケージ化計画
+
+## 目的
+
+* 旧 `backend/ai_meeting.py` に集中している機能を段階的に分割し、
+  パッケージとして管理しやすくする。
+* CLI インターフェース、設定、LLM アダプタなどを明確にモジュール化し、
+  メンテナンス性とテスト容易性を向上させる。
+
+## 段階的移行手順
+
+1. **パッケージ土台の作成（現段階）**
+   * `backend/ai_meeting/` ディレクトリを作成し、`__init__.py` と `__main__.py` を追加する。
+   * `__init__.py` で旧モジュールを動的読み込みし、`main()` へのアクセスポイントを提供する。
+   * `python -m backend.ai_meeting` で従来どおりの CLI を起動できることを確認する。
+
+2. **CLI エントリーポイントの分離**
+   * 旧モジュールから `argparse` 関連コードと `main()` 関数を `cli.py` に移動する。
+   * `__main__.py` と将来の `backend/__init__.py` からは `cli.main()` を呼び出すようにする。
+   * 単体テストで CLI の基本動作を保証する。
+
+3. **設定・データモデルの分割**
+   * `MeetingConfig` や `AgentConfig` などの Pydantic モデルを `config.py` に移行。
+   * デフォルト設定・バリデーション関連を `defaults.py` と `validators.py` に整理。
+   * 旧モジュールでのインポート箇所を順次更新。
+
+4. **LLM バックエンドの独立化**
+   * `LLMBackend`, `OpenAIBackend`, `OllamaBackend` 等を `llm/` サブパッケージ（例: `llm/base.py`, `llm/openai.py`, `llm/ollama.py`）へ移動。
+   * 新サブパッケージでの依存関係を整理し、テスト用モックを準備。
+
+5. **会議ロジックのモジュール化**
+   * 会議進行・ログ関連クラスを `meeting/` サブパッケージ（`controller.py`, `logging.py`, `state.py` など）に移す。
+   * ロジック単位でユニットテストを追加し、回帰防止を図る。
+
+6. **不要コードの整理と最終調整**
+   * 旧 `backend/ai_meeting.py` を最終的に削除し、新しいパッケージ構成に統合。
+   * ドキュメントおよび CLI ヘルプメッセージを最新化する。
+   * CI での静的解析・テストを更新された構成に合わせて整備。
+
+## 最終モジュール構成（案）
+
+```
+backend/
+  ai_meeting/
+    __init__.py          # パッケージ初期化と公開 API
+    __main__.py          # `python -m backend.ai_meeting` 用 CLI ラッパー
+    cli.py               # 引数解析と CLI エントリーポイント
+    config.py            # Pydantic 設定モデル・デフォルト値
+    logging.py           # ログ出力関連ユーティリティ
+    orchestrator.py      # 会議進行のメインロジック
+    participants.py      # エージェント管理・選定ロジック
+    llm/
+      __init__.py
+      base.py            # LLMBackend インターフェース
+      openai.py          # OpenAI 実装
+      ollama.py          # Ollama 実装
+    prompts/
+      __init__.py
+      templates.py       # プロンプトテンプレートと生成ヘルパー
+    utils/
+      __init__.py
+      text.py            # 文字列整形・共通ユーティリティ
+      math.py            # スコア計算などのユーティリティ
+```
+
+上記構成では、CLI・設定・LLM・会議ロジックを独立したモジュールに分割し、
+責務ごとにテストを実施できるようにする。段階的な移行により、既存機能の
+動作を維持しつつ大規模な変更リスクを最小化する。


### PR DESCRIPTION
## Summary
- introduce a `backend.ai_meeting` package that dynamically loads the existing monolithic module and exposes its `main()` entry point
- add a package `__main__` wrapper so `python -m backend.ai_meeting` continues to work during the transition
- document the migration plan and target module layout for refactoring the legacy module

## Testing
- python -m backend.ai_meeting --help

------
https://chatgpt.com/codex/tasks/task_e_68dc0553e7a8832cbacda33d17e8af3f