### PR TITLE
Refactor meeting config and CLI into package modules

### DIFF
--- a/backend/ai_meeting/__init__.py
+++ b/backend/ai_meeting/__init__.py
@@ -1,48 +1,15 @@
-"""`backend.ai_meeting` パッケージの暫定エントリーポイント。
-
-旧 `backend/ai_meeting.py` モジュールをそのまま利用しつつ、
-段階的にパッケージ構成へ移行できるようにする。
-"""
+"""`backend.ai_meeting` パッケージの暫定エントリーポイント。"""
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-from types import ModuleType
-from typing import Callable, Optional, TypeVar, cast
+from ._legacy import get_main, load_legacy_module
+from .cli import main
+from .config import MeetingConfig
+from .meeting import Meeting
 
-__all__ = ["load_legacy_module", "get_main"]
-
-TFunc = TypeVar("TFunc", bound=Callable[..., object])
-
-
-def load_legacy_module() -> ModuleType:
-    """旧 `backend/ai_meeting.py` をモジュールとして読み込む。
-
-    Python の import 解決順はパッケージを優先するため、
-    本パッケージ作成後は `import backend.ai_meeting` が
-    自身を指してしまう。この関数ではファイルパスを指定して
-    旧実装を読み込み、従来の関数を利用できるようにする。
-    """
-
-    package_dir = Path(__file__).resolve().parent
-    legacy_path = package_dir.parent / f"{package_dir.name}.py"
-
-    spec = importlib.util.spec_from_file_location(
-        "backend.ai_meeting_legacy", legacy_path
-    )
-    if spec is None or spec.loader is None:
-        raise ImportError(f"旧モジュールを読み込めませんでした: {legacy_path}")
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def get_main() -> Callable[..., object]:
-    """旧モジュールの `main()` を取得する。"""
-
-    module = load_legacy_module()
-    main_attr: Optional[object] = getattr(module, "main", None)
-    if not callable(main_attr):
-        raise AttributeError("旧モジュールに main() が見つかりません。")
-    return cast(TFunc, main_attr)
+__all__ = [
+    "load_legacy_module",
+    "get_main",
+    "MeetingConfig",
+    "main",
+    "Meeting",
+]

--- a/backend/ai_meeting/__main__.py
+++ b/backend/ai_meeting/__main__.py
@@ -1,14 +1,7 @@
-"""`python -m backend.ai_meeting` 用の暫定ラッパー。"""
+"""`python -m backend.ai_meeting` 用のエントリーポイント。"""
 from __future__ import annotations
 
-from . import get_main
-
-
-def main() -> None:
-    """旧 `main()` を呼び出す。"""
-
-    legacy_main = get_main()
-    legacy_main()
+from .cli import main
 
 
 if __name__ == "__main__":

--- a/backend/ai_meeting/_legacy.py
+++ b/backend/ai_meeting/_legacy.py
@@ -1,0 +1,34 @@
+"""旧 `backend.ai_meeting` モジュールを読み込むための補助。"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Optional, TypeVar, cast
+
+TFunc = TypeVar("TFunc", bound=Callable[..., object])
+
+
+def load_legacy_module() -> ModuleType:
+    """旧 `backend/ai_meeting.py` をモジュールとして読み込む。"""
+
+    package_dir = Path(__file__).resolve().parent
+    legacy_path = package_dir.parent / f"{package_dir.name}.py"
+
+    spec = importlib.util.spec_from_file_location("backend.ai_meeting_legacy", legacy_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"旧モジュールを読み込めませんでした: {legacy_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def get_main() -> Callable[..., object]:
+    """旧モジュールの `main()` を取得する。"""
+
+    module = load_legacy_module()
+    main_attr: Optional[object] = getattr(module, "main", None)
+    if not callable(main_attr):
+        raise AttributeError("旧モジュールに main() が見つかりません。")
+    return cast(TFunc, main_attr)

--- a/backend/ai_meeting/cli.py
+++ b/backend/ai_meeting/cli.py
@@ -1,0 +1,158 @@
+"""CLI 用ユーティリティ。"""
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List
+
+from backend.defaults import DEFAULT_AGENT_NAMES
+
+from .config import AgentConfig, MeetingConfig, clamp
+from .meeting import Meeting
+
+
+def parse_args() -> argparse.Namespace:
+    """CLI 引数を解析して `argparse.Namespace` を返す。"""
+
+    ap = argparse.ArgumentParser(description="CLI AI Meeting (multi-agent)")
+    ap.add_argument("--topic", required=True, help="会議テーマ（日本語OK）")
+    ap.add_argument("--precision", type=int, default=5, help="1=発散寄り, 10=厳密寄り")
+    ap.add_argument(
+        "--agents",
+        nargs="+",
+        default=list(DEFAULT_AGENT_NAMES),
+        help="参加者を列挙。'名前=systemプロンプト' 形式もOK（例: Alice='仕様を詰める' Bob='実装に落とす'）",
+    )
+    ap.add_argument("--rounds", type=int, default=4)
+    ap.add_argument("--backend", choices=["openai", "ollama"], default="ollama")
+    ap.add_argument("--openai-model", default=None)
+    ap.add_argument("--ollama-model", default=None)
+    ap.add_argument(
+        "--no-resolve-round",
+        dest="resolve_round",
+        action="store_false",
+        help="最後の“残課題消化ラウンド”を無効化する",
+    )
+    # 短文チャット（既定ON。OFFにしたいときだけ指定）
+    ap.add_argument(
+        "--no-chat-mode",
+        dest="chat_mode",
+        action="store_false",
+        help="短文チャットモードを無効化する",
+    )
+    ap.add_argument("--chat-max-sentences", type=int, default=2)
+    ap.add_argument("--chat-max-chars", type=int, default=120)
+    ap.add_argument("--chat-window", type=int, default=2)
+    ap.add_argument("--outdir", default=None, help="ログ出力先ディレクトリ（未指定なら自動生成）")
+    # 以降のステップ用（Step 0では未使用。フラグだけ受ける）
+    ap.add_argument(
+        "--equilibrium",
+        action="store_true",
+        help="均衡AI（メタ評価）を有効化（Step 0では未使用）",
+    )
+    ap.add_argument(
+        "--shock",
+        choices=["off", "random", "explore", "exploit"],
+        default="off",
+        help="ショック注入モード（Step 0では未使用）",
+    )
+    ap.add_argument("--shock-ttl", type=int, default=2, help="ショック効果を維持するターン数")
+    # Step 3
+    ap.add_argument("--cooldown", type=float, default=0.10)
+    ap.add_argument("--cooldown-span", type=int, default=1)
+    ap.add_argument("--topk", type=int, default=3)
+    ap.add_argument("--select-temp", type=float, default=0.7)
+    ap.add_argument("--sim-window", type=int, default=6)
+    ap.add_argument("--sim-penalty", type=float, default=0.25)
+    # Step 4
+    ap.add_argument(
+        "--monitor",
+        action="store_true",
+        help="監視AI（フェーズ自動判定）を有効化（裏方のみ）",
+    )
+    ap.add_argument("--phase-window", type=int, default=8)
+    ap.add_argument("--phase-cohesion-min", type=float, default=0.70)
+    ap.add_argument("--phase-unresolved-drop", type=float, default=0.25)
+    ap.add_argument("--phase-loop-threshold", type=int, default=3)
+    # 思考→審査→発言
+    ap.add_argument("--no-think-mode", dest="think_mode", action="store_false")
+    ap.add_argument("--no-think-debug", dest="think_debug", action="store_false")
+    # Step 7
+    ap.add_argument("--kpi-window", type=int, default=6)
+    ap.add_argument("--no-kpi-auto-prompt", dest="kpi_auto_prompt", action="store_false")
+    ap.add_argument("--no-kpi-auto-tune", dest="kpi_auto_tune", action="store_false")
+    ap.add_argument("--th-diversity-min", type=float, default=0.55)
+    ap.add_argument("--th-decision-min", type=float, default=0.40)
+    ap.add_argument("--th-progress-stall", type=int, default=3)
+    ap.add_argument(
+        "--ui-full",
+        dest="ui_minimal",
+        action="store_false",
+        help="従来の見出し・役職ラベルを表示（台本風UIに戻す）",
+    )
+    return ap.parse_args()
+
+
+def build_agents(tokens: List[str]) -> List[AgentConfig]:
+    """エージェント設定を CLI 引数から構築する。"""
+
+    agents: List[AgentConfig] = []
+    default_system = (
+        "あなたは会議参加者です。日本語で短く発言し、直前の内容に具体的に応答し、"
+        "次の一手を提示してください。見出し/箇条書き/長い前置きは禁止"
+    )
+    for raw_token in tokens:
+        raw = raw_token.strip()
+        if "=" in raw:
+            name, system = raw.split("=", 1)
+            agents.append(AgentConfig(name=name.strip(), system=system.strip()))
+        else:
+            agents.append(AgentConfig(name=raw, system=default_system))
+    return agents
+
+
+def main() -> None:
+    """CLI エントリーポイント。"""
+
+    args = parse_args()
+    agents = build_agents(args.agents)
+    cfg = MeetingConfig(
+        topic=args.topic,
+        precision=clamp(args.precision, 1, 10),
+        rounds=args.rounds,
+        agents=agents,
+        backend_name=args.backend,
+        openai_model=args.openai_model or os.getenv("OPENAI_MODEL"),
+        ollama_model=args.ollama_model or os.getenv("OLLAMA_MODEL"),
+        resolve_round=getattr(args, "resolve_round", True),
+        chat_mode=getattr(args, "chat_mode", True),
+        chat_max_sentences=args.chat_max_sentences,
+        chat_max_chars=args.chat_max_chars,
+        chat_window=args.chat_window,
+        outdir=getattr(args, "outdir", None),
+        equilibrium=getattr(args, "equilibrium", False),
+        monitor=getattr(args, "monitor", False),
+        shock=getattr(args, "shock", "off"),
+        shock_ttl=max(1, int(getattr(args, "shock_ttl", 2))),
+        ui_minimal=getattr(args, "ui_minimal", True),
+        cooldown=max(0.0, float(getattr(args, "cooldown", 0.10))),
+        cooldown_span=max(0, int(getattr(args, "cooldown_span", 1))),
+        topk=max(1, int(getattr(args, "topk", 3))),
+        select_temp=max(0.05, float(getattr(args, "select_temp", 0.7))),
+        sim_window=max(0, int(getattr(args, "sim_window", 6))),
+        sim_penalty=max(0.0, float(getattr(args, "sim_penalty", 0.25))),
+        phase_window=max(1, int(getattr(args, "phase_window", 8))),
+        phase_cohesion_min=min(1.0, max(0.0, float(getattr(args, "phase_cohesion_min", 0.70)))),
+        phase_unresolved_drop=min(1.0, max(0.0, float(getattr(args, "phase_unresolved_drop", 0.25)))),
+        phase_loop_threshold=max(1, int(getattr(args, "phase_loop_threshold", 3))),
+        think_mode=getattr(args, "think_mode", True),
+        think_debug=getattr(args, "think_debug", True),
+    )
+    cfg.kpi_window = max(1, int(getattr(args, "kpi_window", 6)))
+    cfg.kpi_auto_prompt = getattr(args, "kpi_auto_prompt", True)
+    cfg.kpi_auto_tune = getattr(args, "kpi_auto_tune", True)
+    cfg.th_diversity_min = max(0.0, float(getattr(args, "th_diversity_min", 0.55)))
+    cfg.th_decision_min = max(0.0, float(getattr(args, "th_decision_min", 0.40)))
+    cfg.th_progress_stall = max(1, int(getattr(args, "th_progress_stall", 3)))
+
+    Meeting(cfg).run()

--- a/backend/ai_meeting/config.py
+++ b/backend/ai_meeting/config.py
@@ -1,0 +1,89 @@
+"""会議設定やエージェント設定に関するデータモデル。"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    """値を下限・上限で挟み込む。"""
+
+    return max(lower, min(upper, value))
+
+
+class AgentConfig(BaseModel):
+    """各会議参加エージェントの設定。"""
+
+    name: str
+    system: str
+    style: str = ""  # 口調など任意
+    reveal_think: bool = False  # trueだと“思考ログ”も表示（研修用）
+
+
+@dataclass
+class Turn:
+    """会議内の1発言を表すデータ構造。"""
+
+    speaker: str
+    content: str
+    meta: Dict = field(default_factory=dict)
+
+
+class MeetingConfig(BaseModel):
+    """会議全体に関する設定値。"""
+
+    topic: str = Field(..., description="会議テーマ（1文）")
+    precision: int = Field(5, ge=1, le=10, description="精密性(1=発散, 10=厳密)")
+    rounds: int = 4
+    agents: List[AgentConfig]
+    backend_name: Literal["openai", "ollama"] = "ollama"
+    openai_model: Optional[str] = None
+    ollama_model: Optional[str] = None
+    max_tokens: int = 800
+    resolve_round: bool = True  # 最後に「残課題消化ラウンド」を自動挿入
+    # --- 短文チャット（既定ON） ---
+    chat_mode: bool = True
+    chat_max_sentences: int = 2
+    chat_max_chars: int = 120
+    chat_window: int = 2  # 直近何発言を見せるか
+    # --- 以降のステップ用プレースホルダ（Step 0では未使用） ---
+    equilibrium: bool = False  # 均衡AI（メタ評価）
+    monitor: bool = False  # 監視AI（フェーズ検知）
+    shock: Literal["off", "random", "explore", "exploit"] = "off"  # ショック注入モード
+    shock_ttl: int = 2  # ショックを維持するターン数（フェーズ確定後の有効ターン）
+    # --- Step 1: UI最小化（台本感を消す表示） ---
+    ui_minimal: bool = True  # 役職やRound見出しを出さない
+    # --- Step 3: 多様性＆独占ガード ---
+    cooldown: float = 0.10  # 直近発言者への減点（0.0-1.0）
+    cooldown_span: int = 1  # 何ターン遡ってクールダウンを適用するか
+    topk: int = 3  # 上位Kから抽選
+    select_temp: float = 0.7  # ソフトマックス温度（小さいほど貪欲）
+    sim_window: int = 6  # 類似度の参照ターン数（直近W）
+    sim_penalty: float = 0.25  # 類似度ペナルティの係数（0.0-1.0）
+    # --- Step 4: 監視AI + フェーズ自動判定（裏方のみ） ---
+    phase_window: int = 8  # 直近W発言でまとまり度を判定
+    phase_cohesion_min: float = 0.70  # フェーズ確定に必要な“まとまり度”下限（0-1）
+    phase_unresolved_drop: float = 0.25  # 未解決が W 内でこの割合以上減ったらOK
+    phase_loop_threshold: int = 3  # 高類似ループK回でフェーズ確定
+    # ---- Step8前: 思考→審査→発言（T3→T1）MVP ----
+    think_mode: bool = True  # 全員が非公開の「思考」を出してから発言者を決める
+    think_debug: bool = True  # thoughts.jsonl に全思考・採点を保存（本文には出さない）
+    # --- Step 7: KPIフィードバック制御 ---
+    kpi_window: int = 6  # 直近W発言でミニKPIを算出
+    kpi_auto_prompt: bool = True  # 閾値割れで隠しプロンプトを注入
+    kpi_auto_tune: bool = True  # 閾値割れでパラメータ自動調整
+    th_diversity_min: float = 0.55  # 多様性の下限（下回ると発散要求）
+    th_decision_min: float = 0.40  # 決定密度の下限（下回ると担当/期限を強制）
+    th_progress_stall: int = 3  # 未解決がW中ずっと横ばい/悪化なら収束促進
+
+    outdir: Optional[str] = None  # ログ出力先。未指定なら自動で logs/<日時_トピック> を作成
+
+    def runtime_params(self) -> Dict[str, Union[float, int]]:
+        """precision に応じた温度やクリティーク回数を算出する。"""
+
+        p = self.precision
+        temperature = clamp(1.1 - (p / 10) * 0.8, 0.2, 1.0)  # p↑で温度↓
+        critique_passes = clamp(int(round((p / 10) * 2)), 0, 2)  # 0~2回
+        return {"temperature": temperature, "critique_passes": critique_passes}

--- a/backend/ai_meeting/meeting.py
+++ b/backend/ai_meeting/meeting.py
@@ -1,0 +1,26 @@
+"""会議制御用の新しいラッパークラス。"""
+from __future__ import annotations
+
+from typing import Any
+
+from ._legacy import load_legacy_module
+from .config import MeetingConfig
+
+
+class Meeting:
+    """旧実装を内部で利用するラッパー。"""
+
+    def __init__(self, cfg: MeetingConfig):
+        legacy_module = load_legacy_module()
+        legacy_cls = getattr(legacy_module, "Meeting", None)
+        if legacy_cls is None:
+            raise AttributeError("旧実装に Meeting クラスが見つかりません。")
+        self._impl = legacy_cls(cfg)
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """旧 Meeting#run を呼び出す。"""
+
+        return self._impl.run(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._impl, name)


### PR DESCRIPTION
## Summary
- add backend.ai_meeting.config to host AgentConfig, Turn, MeetingConfig, and utility helpers
- extract CLI helpers into backend.ai_meeting.cli and provide a Meeting wrapper inside the package
- update package exports and legacy loader wiring so existing entry points keep working

## Testing
- python -m backend.ai_meeting --help

------
https://chatgpt.com/codex/tasks/task_e_68dc07c1a0d4832c8b0a63b8673fe7cf