### PR TITLE
Update documentation links to new backend modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 AI Meeting は、大規模言語モデル (LLM) を複数名の参加者として協調させる会議シミュレーターです。バックエンドは Python 製の CLI スクリプトで、任意の名前とプロンプトを与えた参加者が議論し、ログや KPI を自動で記録します。フロントエンドは React/Vite 製の簡易ビューワーで、生成されたログをタイムライン形式で閲覧できます。
 
 ## 主な機能
-- **マルチエージェント会議進行**：任意の参加者名とシステムプロンプトを組み合わせ、短文チャット制約の下で思考→審査→発言を繰り返し、ラウンド要約や残課題解消ラウンドも自動化されています。【F:backend/ai_meeting.py†L103-L154】【F:backend/ai_meeting.py†L672-L1047】
-- **ログ生成と分析**：`meeting_live.md` / `meeting_live.jsonl` / `meeting_result.json` をはじめ、CPU・GPU 利用率の時系列 (`metrics.csv` やグラフ画像) を保存します。【F:backend/ai_meeting.py†L156-L270】【F:backend/ai_meeting.py†L1045-L1093】
-- **KPI 評価とフィードバック**：議論の多様性・決定密度などを自動計測し、閾値割れ時にはプロンプトを調整する仕組みを備えています。【F:backend/ai_meeting.py†L262-L312】【F:backend/ai_meeting.py†L1065-L1074】
+- **マルチエージェント会議進行**：任意の参加者名とシステムプロンプトを組み合わせ、短文チャット制約の下で思考→審査→発言を繰り返し、ラウンド要約や残課題解消ラウンドも自動化されています。【F:backend/ai_meeting/config.py†L30-L85】【F:backend/ai_meeting/meeting.py†L281-L507】
+- **ログ生成と分析**：`meeting_live.md` / `meeting_live.jsonl` / `meeting_result.json` をはじめ、CPU・GPU 利用率の時系列 (`metrics.csv` やグラフ画像) を保存します。【F:backend/ai_meeting/logging.py†L14-L139】【F:backend/ai_meeting/meeting.py†L541-L564】
+- **KPI 評価とフィードバック**：議論の多様性・決定密度などを自動計測し、閾値割れ時にはプロンプトを調整する仕組みを備えています。【F:backend/ai_meeting/controllers.py†L87-L145】【F:backend/ai_meeting/evaluation.py†L10-L47】
 - **フロントエンド表示**：生成ログをポーリングしてタイムライン・要約・KPI を表示する React UI を提供します。【F:frontend/src/pages/Meeting.jsx†L1-L96】【F:frontend/src/pages/Result.jsx†L8-L58】
 
 > 🔰 **初心者向けガイド**
@@ -48,9 +48,9 @@ Meeting(cfg).run()
    ```bash
    pip install pydantic psutil matplotlib pynvml GPUtil requests openai
    ```
-   ※ `pynvml` や `GPUtil` は GPU 利用率を取得したいときのみ必須です。【F:backend/ai_meeting.py†L325-L408】
-2. Ollama を利用する場合は `ollama run llama3` などでローカルサーバーを立ち上げておきます (既定は `http://localhost:11434`)。【F:backend/ai_meeting.py†L60-L87】
-3. OpenAI を利用する場合は `OPENAI_API_KEY` と必要なら `OPENAI_MODEL` を環境変数に設定します。【F:backend/ai_meeting.py†L41-L57】
+   ※ `pynvml` や `GPUtil` は GPU 利用率を取得したいときのみ必須です。【F:backend/ai_meeting/metrics.py†L17-L93】
+2. Ollama を利用する場合は `ollama run llama3` などでローカルサーバーを立ち上げておきます (既定は `http://localhost:11434`)。【F:backend/ai_meeting/llm.py†L55-L80】
+3. OpenAI を利用する場合は `OPENAI_API_KEY` と必要なら `OPENAI_MODEL` を環境変数に設定します。【F:backend/ai_meeting/llm.py†L27-L52】
 4. 会議を実行します。例：
    ```bash
    python backend/ai_meeting.py \
@@ -64,19 +64,19 @@ Meeting(cfg).run()
    実行すると `logs/<日時_トピック>/` 以下にログ一式が出力されます。
 
 ### 主要な CLI オプション
-- `--precision`：1 (発散型)〜10 (厳密型) の指標で温度や自己検証回数を調整します。【F:backend/ai_meeting.py†L103-L154】【F:backend/ai_meeting.py†L1134-L1140】
-- `--agents`：参加者名を順番に指定。`名前=systemプロンプト` 形式を混在させると個別ルールを注入できます。【F:backend/ai_meeting.py†L1134-L1140】【F:backend/ai_meeting.py†L1186-L1199】
-- `--chat-mode/--no-chat-mode`：短文チャット制約の ON/OFF。文数や文字数制限 (`--chat-max-sentences` / `--chat-max-chars`) も変更可能です。【F:backend/ai_meeting.py†L1146-L1151】【F:backend/ai_meeting.py†L749-L839】
-- `--resolve-round`：残課題をまとめて解消するラウンドを挿入するかどうか。【F:backend/ai_meeting.py†L112-L122】【F:backend/ai_meeting.py†L1027-L1049】
-- `--think-mode`：思考→審査→発言 (T3→T1) のプロセスを有効化/無効化します。【F:backend/ai_meeting.py†L137-L140】【F:backend/ai_meeting.py†L872-L913】
-- `--outdir`：ログ出力先を明示指定。未指定なら自動で `logs/<日時_トピック>` を作成します。【F:backend/ai_meeting.py†L148-L204】
+- `--precision`：1 (発散型)〜10 (厳密型) の指標で温度や自己検証回数を調整します。【F:backend/ai_meeting/config.py†L30-L85】【F:backend/ai_meeting/meeting.py†L28-L43】
+- `--agents`：参加者名を順番に指定。`名前=systemプロンプト` 形式を混在させると個別ルールを注入できます。【F:backend/ai_meeting/cli.py†L97-L112】【F:backend/ai_meeting/config.py†L12-L19】
+- `--chat-mode/--no-chat-mode`：短文チャット制約の ON/OFF。文数や文字数制限 (`--chat-max-sentences` / `--chat-max-chars`) も変更可能です。【F:backend/ai_meeting/config.py†L43-L47】【F:backend/ai_meeting/meeting.py†L247-L264】
+- `--resolve-round`：残課題をまとめて解消するラウンドを挿入するかどうか。【F:backend/ai_meeting/config.py†L41-L47】【F:backend/ai_meeting/meeting.py†L481-L505】
+- `--think-mode`：思考→審査→発言 (T3→T1) のプロセスを有効化/無効化します。【F:backend/ai_meeting/config.py†L66-L68】【F:backend/ai_meeting/meeting.py†L297-L320】
+- `--outdir`：ログ出力先を明示指定。未指定なら自動で `logs/<日時_トピック>` を作成します。【F:backend/ai_meeting/config.py†L77-L78】【F:backend/ai_meeting/logging.py†L14-L44】
 
 ## ログファイルの構成
-- `meeting_live.jsonl`：1 行 1 発言の JSON Lines。フロントエンドのタイムラインが参照します。【F:backend/ai_meeting.py†L182-L242】【F:frontend/src/services/api.js†L17-L37】
+- `meeting_live.jsonl`：1 行 1 発言の JSON Lines。フロントエンドのタイムラインが参照します。【F:backend/ai_meeting/logging.py†L14-L107】【F:frontend/src/services/api.js†L17-L37】
 - `meeting_live.md`：人が読みやすい Markdown ログ。
-- `meeting_result.json`：会議設定・最終合意案・発言履歴をまとめた JSON。【F:backend/ai_meeting.py†L1052-L1087】
-- `phases.jsonl` / `thoughts.jsonl`：フェーズ推定や思考ログ (デバッグ用)。
-- `metrics.csv` / `metrics_cpu_mem.png` / `metrics_gpu.png`：CPU/GPU の稼働状況を記録したファイル。【F:backend/ai_meeting.py†L325-L408】
+- `meeting_result.json`：会議設定・最終合意案・発言履歴をまとめた JSON。【F:backend/ai_meeting/meeting.py†L542-L558】
+- `phases.jsonl` / `thoughts.jsonl`：フェーズ推定や思考ログ (デバッグ用)。【F:backend/ai_meeting/logging.py†L23-L77】【F:backend/ai_meeting/meeting.py†L297-L437】
+- `metrics.csv` / `metrics_cpu_mem.png` / `metrics_gpu.png`：CPU/GPU の稼働状況を記録したファイル。【F:backend/ai_meeting/metrics.py†L17-L148】
 
 ## フロントエンドのセットアップとプレビュー
 1. Node.js 18 以上を用意し、依存関係をインストールします。

--- a/docs/meeting_logging.md
+++ b/docs/meeting_logging.md
@@ -1,21 +1,21 @@
 # Meeting ログと検証用サンプル
 
 ## LiveLogWriter が生成するファイル
-- `meeting_live.md`: UI最小化モードでは「Topic」「Final」などの見出しのみを付けて逐次の発言・要約・最終結論を書き込むMarkdownログ。各ラウンド要約は `（要約）...` 形式、最終セクションは `【Final】` 見出しで追記される。【F:backend/ai_meeting.py†L173-L254】
-- `meeting_live.jsonl`: 各発言・要約・最終決定を `ts/type/round/turn/speaker/content` などのキーで1行JSONとして蓄積するライブログ。`type` は `"turn"`/`"summary"`/`"final"` をとる。【F:backend/ai_meeting.py†L198-L261】
-- `phases.jsonl`: 監視AI（Monitor）がフェーズ確定時に書き出すメタ情報。本文には挿入せず、`cohesion` や `phase_id` などの裏方データのみをJSONLで保持する。【F:backend/ai_meeting.py†L208-L520】
-- `thoughts.jsonl`: 思考→審査フローを有効化した場合に、各ラウンドの全エージェント思考と審査結果を格納するデバッグ用ログ。【F:backend/ai_meeting.py†L213-L218】【F:backend/ai_meeting.py†L932-L948】
-- `control.jsonl`: KPIフィードバックが閾値を下回った際に自動生成される制御ログ。`type="kpi_control"` に各種指標とヒントを付与して保存する。【F:backend/ai_meeting.py†L219-L223】【F:backend/ai_meeting.py†L1032-L1042】
-- `kpi.json`: 会議終了時のKPI指標（progress/diversity/decision_density/spec_coverage）をJSONで保存し、同時にMarkdownにも反映する。【F:backend/ai_meeting.py†L263-L314】
-- `meeting_live.html`: 将来のHTMLビューア用にパスだけ予約されているが、現状は未書き込み。`LiveLogWriter` 初期化時にファイルパスが確保される。【F:backend/ai_meeting.py†L162-L176】
+- `meeting_live.md`: UI最小化モードでは「Topic」「Final」などの見出しのみを付けて逐次の発言・要約・最終結論を書き込むMarkdownログ。各ラウンド要約は `（要約）...` 形式、最終セクションは `【Final】` 見出しで追記される。【F:backend/ai_meeting/logging.py†L14-L139】
+- `meeting_live.jsonl`: 各発言・要約・最終決定を `ts/type/round/turn/speaker/content` などのキーで1行JSONとして蓄積するライブログ。`type` は `"turn"`/`"summary"`/`"final"` をとる。【F:backend/ai_meeting/logging.py†L14-L139】
+- `phases.jsonl`: 監視AI（Monitor）がフェーズ確定時に書き出すメタ情報。本文には挿入せず、`cohesion` や `phase_id` などの裏方データのみをJSONLで保持する。【F:backend/ai_meeting/logging.py†L23-L70】【F:backend/ai_meeting/meeting.py†L420-L437】
+- `thoughts.jsonl`: 思考→審査フローを有効化した場合に、各ラウンドの全エージェント思考と審査結果を格納するデバッグ用ログ。【F:backend/ai_meeting/logging.py†L24-L77】【F:backend/ai_meeting/meeting.py†L297-L320】
+- `control.jsonl`: KPIフィードバックが閾値を下回った際に自動生成される制御ログ。`type="kpi_control"` に各種指標とヒントを付与して保存する。【F:backend/ai_meeting/logging.py†L79-L84】【F:backend/ai_meeting/meeting.py†L448-L468】
+- `kpi.json`: 会議終了時のKPI指標（progress/diversity/decision_density/spec_coverage）をJSONで保存し、同時にMarkdownにも反映する。【F:backend/ai_meeting/logging.py†L128-L139】【F:backend/ai_meeting/meeting.py†L531-L537】
+- `meeting_live.html`: 将来のHTMLビューア用にパスだけ予約されているが、現状は未書き込み。`LiveLogWriter` 初期化時にファイルパスが確保される。【F:backend/ai_meeting/logging.py†L14-L43】
 
 ## MetricsLogger が生成するファイル
-- `metrics.csv`: サンプリング時刻・CPU/RAM・GPU各種指標（利用率、VRAM使用量、温度、電力）を列として追記するCSV。`stop()` 時にこの内容を参照してグラフ生成を試みる。【F:backend/ai_meeting.py†L327-L398】
-- `metrics_cpu_mem.png` / `metrics_gpu.png`: `metrics.csv` を読み取り `matplotlib` でCPU/RAM曲線、GPU関連曲線を描画したPNG。ライブラリが無い環境では例外が握りつぶされるため未生成の場合もある。【F:backend/ai_meeting.py†L407-L465】
+- `metrics.csv`: サンプリング時刻・CPU/RAM・GPU各種指標（利用率、VRAM使用量、温度、電力）を列として追記するCSV。`stop()` 時にこの内容を参照してグラフ生成を試みる。【F:backend/ai_meeting/metrics.py†L17-L93】【F:backend/ai_meeting/meeting.py†L559-L564】
+- `metrics_cpu_mem.png` / `metrics_gpu.png`: `metrics.csv` を読み取り `matplotlib` でCPU/RAM曲線、GPU関連曲線を描画したPNG。ライブラリが無い環境では例外が握りつぶされるため未生成の場合もある。【F:backend/ai_meeting/metrics.py†L94-L148】
 
 ## Meeting.run の最終成果物
-- `meeting_result.json`: 会議設定（topic/precision/rounds/agents）と全ターンの発言、最終結論をまとめたJSON。CLI実行時の成果物として `logs/<タイムスタンプ_トピック>/` 直下に保存される。【F:backend/ai_meeting.py†L1126-L1138】
-- 上記以外にもCLI標準出力ではライブログの保存先とメトリクスファイル名が案内される。【F:backend/ai_meeting.py†L1126-L1144】
+- `meeting_result.json`: 会議設定（topic/precision/rounds/agents）と全ターンの発言、最終結論をまとめたJSON。CLI実行時の成果物として `logs/<タイムスタンプ_トピック>/` 直下に保存される。【F:backend/ai_meeting/meeting.py†L542-L564】
+- 上記以外にもCLI標準出力ではライブログの保存先とメトリクスファイル名が案内される。【F:backend/ai_meeting/meeting.py†L541-L564】
 
 ## 代表的なCLI実行例とサンプル
 以下のコマンドを実行すると、スタブOpenAIバックエンドを利用した2ラウンドの会議が `logs/sample_cli_run/` に出力される。
@@ -48,6 +48,6 @@ python -m backend.ai_meeting \
 | D: 監視AIあり | 有効 | 有効 | 有効 | 有効 | random | 有効 | `phases.jsonl` 生成とショック寿命の連動確認 |
 | E: 思考なしモード | 無効 | 無効 | 有効 | 無効 | exploit | 無効 | 旧来の発言生成フローと`thoughts.jsonl`非生成の確認 |
 
-- `think_mode`/`think_debug`/`shock`/`monitor` は CLI で直接指定可能な主要スイッチであり、ログ生成パスや補助ファイル出力の有無が変わる。【F:backend/ai_meeting.py†L924-L1054】【F:backend/ai_meeting.py†L1200-L1293】
-- KPI系フラグを無効化した場合は `control.jsonl` への書き込みや自動チューニング分岐がスキップされるため、ケースB/Eでその挙動差をカバーする。【F:backend/ai_meeting.py†L1027-L1043】
-- ショックモードは `shock` 引数で `random/explore/exploit` を選べ、フェーズ確定時にクールダウンや選択温度へ影響するためケースC/Dで確認する。【F:backend/ai_meeting.py†L1003-L1021】
+- `think_mode`/`think_debug`/`shock`/`monitor` は CLI で直接指定可能な主要スイッチであり、ログ生成パスや補助ファイル出力の有無が変わる。【F:backend/ai_meeting/cli.py†L37-L93】【F:backend/ai_meeting/meeting.py†L297-L468】
+- KPI系フラグを無効化した場合は `control.jsonl` への書き込みや自動チューニング分岐がスキップされるため、ケースB/Eでその挙動差をカバーする。【F:backend/ai_meeting/meeting.py†L448-L468】【F:backend/ai_meeting/controllers.py†L87-L145】
+- ショックモードは `shock` 引数で `random/explore/exploit` を選べ、フェーズ確定時にクールダウンや選択温度へ影響するためケースC/Dで確認する。【F:backend/ai_meeting/meeting.py†L420-L466】【F:backend/ai_meeting/controllers.py†L160-L195】


### PR DESCRIPTION
## Summary
- refresh meeting logging documentation to point at the new logging and metrics modules
- update README references to the split backend package so feature descriptions cite the correct files

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dcd750a60c832c971420642f5e4563