### PR TITLE
Fetch meeting results and enable downloads on result page

### DIFF
--- a/frontend/src/pages/Result.jsx
+++ b/frontend/src/pages/Result.jsx
@@ -1,21 +1,58 @@
-import { useLocation, useParams } from "react-router-dom";
-
-function useQuery() {
-  const { search } = useLocation();
-  return new URLSearchParams(search);
-}
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getMeetingResult } from "../services/api";
 
 export default function Result() {
   const { id } = useParams();
-  const q = useQuery();
-  const topic = q.get("topic") || "（無題）";
-  const final = decodeURIComponent(q.get("final") || "（Finalは未取得）");
-  let kpi;
-  try {
-    kpi = JSON.parse(decodeURIComponent(q.get("kpi") || "{}"));
-  } catch {
-    kpi = {};
-  }
+  const [result, setResult] = useState(null);
+  const [status, setStatus] = useState("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("loading");
+    setResult(null);
+    getMeetingResult(id)
+      .then((data) => {
+        if (cancelled) return;
+        setResult(data);
+        setStatus("success");
+      })
+      .catch((err) => {
+        console.error(err);
+        if (cancelled) return;
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const topic = result?.topic || "（無題）";
+  const final = result?.final || "（Finalは未取得）";
+  const kpi = result?.kpi || {};
+  const files = result?.files || {};
+
+  const filePath = (candidates) => {
+    for (const key of candidates) {
+      if (files[key]) return files[key];
+    }
+    return null;
+  };
+
+  const downloads = [
+    {
+      label: "meeting_live.md をDL",
+      path: filePath(["meeting_live_md", "meeting_live", "meeting_live.md"]),
+    },
+    {
+      label: "metrics.csv をDL",
+      path: filePath(["metrics_csv", "metrics", "metrics.csv"]),
+    },
+    {
+      label: "metrics_cpu_mem.png をDL",
+      path: filePath(["metrics_cpu_mem_png", "metrics_cpu_mem", "metrics_cpu_mem.png"]),
+    },
+  ];
 
   const items = [
     { key: "progress", label: "Progress" },
@@ -23,6 +60,23 @@ export default function Result() {
     { key: "decision_density", label: "Decision Density" },
     { key: "spec_coverage", label: "Spec Coverage" },
   ];
+
+  const statusMessage =
+    status === "loading"
+      ? "結果を読み込み中です..."
+      : "結果の取得に失敗しました。時間を置いて再度お試しください。";
+
+  if (status !== "success") {
+    return (
+      <section className="grid-2">
+        <div className="card">
+          <h2 className="title-sm">Final</h2>
+          <div className="muted">Meeting ID: {id}</div>
+          <p className="muted">{statusMessage}</p>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="grid-2">
@@ -33,11 +87,24 @@ export default function Result() {
         <pre className="final">{final}</pre>
 
         <div className="actions">
-          <button className="btn ghost" disabled>meeting_live.md をDL</button>
-          <button className="btn ghost" disabled>metrics.csv をDL</button>
-          <button className="btn ghost" disabled>metrics_cpu_mem.png をDL</button>
+          {downloads.map(({ label, path }) =>
+            path ? (
+              <a
+                key={label}
+                className="btn ghost"
+                href={path}
+                download
+                rel="noreferrer"
+              >
+                {label}
+              </a>
+            ) : (
+              <button key={label} className="btn ghost" disabled>
+                {label}
+              </button>
+            )
+          )}
         </div>
-        <div className="hint">※ 今はダミー。後でログ/画像が生成されたら有効化。</div>
       </div>
 
       <aside className="card">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,14 @@
 // frontend/src/services/api.js
 
+// キャッシュバスター用のクエリを付与
+function withCacheBuster(url) {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}t=${Date.now()}`;
+}
+
 // JSONL (1行 = 1 JSON) を配列に変換
 export async function fetchJSONL(url) {
-  const res = await fetch(url + `?t=${Date.now()}`, { cache: "no-store" });
+  const res = await fetch(withCacheBuster(url), { cache: "no-store" });
   if (!res.ok) throw new Error(`fetch failed: ${res.status} ${url}`);
   const text = await res.text();
   return text
@@ -33,8 +39,55 @@ export async function getTimeline(meetingId) {
 
 // “完了”の簡易判定に使う存在チェック（resultがあれば完了とみなす）
 export async function existsResult(meetingId) {
-  const res = await fetch(`/logs/${meetingId}/meeting_result.json?t=${Date.now()}`, { method: "HEAD" });
+  const res = await fetch(withCacheBuster(`/logs/${meetingId}/meeting_result.json`), { method: "HEAD" });
   return res.ok;
+}
+
+// meeting_result.json（Final/KPI/関連ファイル情報）を取得
+export async function getMeetingResult(meetingId) {
+  const res = await fetch(withCacheBuster(`/logs/${meetingId}/meeting_result.json`), {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`fetch failed: ${res.status} /logs/${meetingId}/meeting_result.json`);
+  }
+  const payload = await res.json();
+  const kpi = payload.kpi ?? payload.metrics ?? {};
+  const files = await ensureFilesExist(payload.files ?? {}, meetingId);
+  return {
+    topic: payload.topic ?? "",
+    final: payload.final ?? "",
+    kpi,
+    files,
+  };
+}
+
+async function ensureFilesExist(files, meetingId) {
+  const entries = Object.entries(files);
+  if (!entries.length) return {};
+  const checked = await Promise.all(
+    entries.map(async ([key, path]) => {
+      if (!path) return [key, null];
+      const target = normalizeFilePath(path, meetingId);
+      if (!target) return [key, null];
+      try {
+        const headRes = await fetch(withCacheBuster(target), { method: "HEAD" });
+        if (!headRes.ok) return [key, null];
+      } catch {
+        return [key, null];
+      }
+      return [key, target];
+    })
+  );
+  return Object.fromEntries(checked.filter(([, path]) => Boolean(path)));
+}
+
+function normalizeFilePath(path, meetingId) {
+  if (!path) return null;
+  if (/^https?:\/\//.test(path) || path.startsWith("/")) {
+    return path;
+  }
+  return `/logs/${meetingId}/${path}`;
 }
 
 export async function startMeeting(payload) {


### PR DESCRIPTION
## Summary
- add a helper for fetching meeting_result.json that returns final, KPI, and verified file links
- load result data through the new helper, show loading/error states, and enable download buttons when files exist

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd22972ed0832cafca51b4740e7a9c