### PR TITLE
feat: surface live meeting KPI snapshot

### DIFF
--- a/frontend/src/pages/Meeting.jsx
+++ b/frontend/src/pages/Meeting.jsx
@@ -1,14 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getTimeline, existsResult } from "@/services/api";
+import { getLiveSnapshot } from "@/services/api";
 
 export default function Meeting() {
   const { id: meetingId } = useParams();      // ← URLの :id が “logs のフォルダ名” と一致している必要あり
   const nav = useNavigate();
 
   const [msgs, setMsgs] = useState([]);
-  const [done, setDone] = useState(false);
+  const [resultReady, setResultReady] = useState(false);
   const [lastChangeAt, setLastChangeAt] = useState(Date.now());
+  const [summary, setSummary] = useState("");
+  const [kpi, setKpi] = useState(null);
+  const [progress, setProgress] = useState(null);
+  const [autoCompleted, setAutoCompleted] = useState(false);
   const listRef = useRef(null);
 
   // ポーリング：5秒ごとに meeting_live.jsonl を読む
@@ -17,17 +21,22 @@ export default function Meeting() {
 
     const tick = async () => {
       try {
-        const [arr, hasResult] = await Promise.all([
-          getTimeline(meetingId),
-          existsResult(meetingId),
-        ]);
+        const snapshot = await getLiveSnapshot(meetingId);
 
         setMsgs(prev => {
-          if (arr.length !== prev.length) setLastChangeAt(Date.now());
-          return arr;
+          if (snapshot.timeline.length !== prev.length) {
+            setLastChangeAt(Date.now());
+            setAutoCompleted(false);
+          }
+          return snapshot.timeline;
         });
 
-        if (hasResult) setDone(true);
+        setSummary(snapshot.summary || "");
+        setKpi(snapshot.kpi);
+        setProgress(snapshot.progress);
+        if (snapshot.resultReady) {
+          setResultReady(true);
+        }
       } catch (_) {
         // 読み込み失敗は無視（次のtickで再試行）
       }
@@ -38,13 +47,25 @@ export default function Meeting() {
     return () => { stop = true; };
   }, [meetingId]);
 
+  useEffect(() => {
+    setMsgs([]);
+    setSummary("");
+    setKpi(null);
+    setProgress(null);
+    setResultReady(false);
+    setAutoCompleted(false);
+    setLastChangeAt(Date.now());
+  }, [meetingId]);
+
   // “完了らしさ”の補助判定：30秒間メッセージ数が増えなければ done 扱い
   useEffect(() => {
     const iv = setInterval(() => {
-      if (Date.now() - lastChangeAt > 30000) setDone(true);
+      if (!resultReady && Date.now() - lastChangeAt > 30000) {
+        setAutoCompleted(true);
+      }
     }, 5000);
     return () => clearInterval(iv);
-  }, [lastChangeAt]);
+  }, [lastChangeAt, resultReady]);
 
   // 自動スクロール
   useEffect(() => {
@@ -52,12 +73,33 @@ export default function Meeting() {
     listRef.current.scrollTop = listRef.current.scrollHeight;
   }, [msgs]);
 
-  // 直近3件のダミー要約（後でバックエンド要約に差し替え）
-  const summary = useMemo(() => {
-    if (!msgs.length) return "（要約はここに流れます）";
+  const memoSummary = useMemo(() => {
+    if (summary && summary.trim().length > 0) return summary;
+    if (!msgs.length) return "（要約はまだ生成されていません）";
     const tail = msgs.slice(-3).map(m => `・${m.text}`).join("\n");
-    return `直近の要点:\n${tail}`;
-  }, [msgs]);
+    return `直近の要点（暫定）:\n${tail}`;
+  }, [summary, msgs]);
+
+  const progressPercent = useMemo(() => {
+    if (typeof progress !== "number" || Number.isNaN(progress)) return null;
+    const clamped = Math.min(1, Math.max(0, progress));
+    return Math.round(clamped * 100);
+  }, [progress]);
+
+  const done = resultReady || (progressPercent !== null && progressPercent >= 99) || autoCompleted;
+
+  const badge = resultReady
+    ? { className: "ok", label: "完了" }
+    : progressPercent !== null
+      ? { className: "run", label: `集計中 ${progressPercent}%` }
+      : { className: "run", label: done ? "終盤" : "進行中" };
+
+  const kpiItems = useMemo(() => ([
+    { key: "progress", label: "Progress" },
+    { key: "diversity", label: "Diversity" },
+    { key: "decision_density", label: "Decision Density" },
+    { key: "spec_coverage", label: "Spec Coverage" },
+  ]), []);
 
   const toResult = () => nav(`/result/${meetingId}`);
 
@@ -66,7 +108,7 @@ export default function Meeting() {
       <div className="card">
         <div className="row-between">
           <h2 className="title-sm">進行中の会議</h2>
-          <span className={`badge ${done ? "ok" : "run"}`}>{done ? "完了" : "進行中"}</span>
+          <span className={`badge ${badge.className}`}>{badge.label}</span>
         </div>
         <div className="muted">Meeting ID: {meetingId}</div>
 
@@ -82,14 +124,40 @@ export default function Meeting() {
 
         <div className="actions">
           <button className="btn ghost" onClick={() => nav("/")}>中止して戻る</button>
-          <button className="btn" onClick={toResult} disabled={!done}>結果へ</button>
+          <button className="btn" onClick={toResult} disabled={!resultReady}>結果へ</button>
         </div>
+        {!resultReady && (
+          <div className="hint">meeting_result.json の生成完了後にボタンが有効になります。</div>
+        )}
       </div>
 
       <aside className="card">
         <h3 className="title-sm">要約</h3>
-        <pre className="summary">{summary}</pre>
-        <div className="hint">※ 現在はフロント側の簡易要約。後でバックエンドに差し替え。</div>
+        <pre className="summary">{memoSummary}</pre>
+        <div className="hint">
+          {resultReady
+            ? "バックエンドから受け取った最終要約です。"
+            : summary
+              ? "バックエンド計算の最新ラウンド要約です。"
+              : "要約算出を待機中です。"}
+        </div>
+        <div className="hint">
+          {progressPercent !== null
+            ? `KPI Progress: ${progressPercent}%`
+            : "KPI 指標を計算中です。"}
+        </div>
+        {kpi && Object.keys(kpi).length > 0 && (
+          <div className="kpi-grid inline">
+            {kpiItems.map(({ key, label }) => (
+              <div className="kpi" key={key}>
+                <div className="kpi-label">{label}</div>
+                <div className="kpi-value">
+                  {typeof kpi[key] === "number" ? kpi[key].toFixed(2) : "—"}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </aside>
     </section>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -30,6 +30,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .muted{color:var(--muted);font-size:13px;margin-top:2px}
 .hint{color:var(--muted);font-size:12px;margin-top:8px}
 .kpi-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
+.kpi-grid.inline{margin-top:12px}
 .kpi{background:#0d0e13;border:1px solid var(--border);border-radius:12px;padding:12px}
 .kpi-label{color:var(--muted);font-size:12px;margin-bottom:4px}
 .kpi-value{font-size:20px;font-weight:700}


### PR DESCRIPTION
## Summary
- collect live meeting timeline, backend summary, KPI, and result readiness from the existing log files
- update the Meeting page to display backend-provided summary/KPI data and gate the result navigation on meeting_result.json readiness
- adjust KPI grid styling to support the inline preview on the Meeting page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2b90c0f0832c94a8adfccb089ddf