### PR TITLE
Add KPI metadata to meeting result payload

### DIFF
--- a/docs/samples/basic_cli_run/meeting_result.json
+++ b/docs/samples/basic_cli_run/meeting_result.json
@@ -35,5 +35,23 @@
       "meta": {}
     }
   ],
-  "final": "合意事項:\n- 議題に向けた初期対応を進める\n残課題:\n- 詳細な要件整理が未完了\n直近アクション:\n- 担当者が次回ミーティングまでに選択肢を比較"
+  "final": "合意事項:\n- 議題に向けた初期対応を進める\n残課題:\n- 詳細な要件整理が未完了\n直近アクション:\n- 担当者が次回ミーティングまでに選択肢を比較",
+  "kpi": {
+    "progress": 0.0,
+    "diversity": 0.0,
+    "decision_density": 0.0,
+    "spec_coverage": 0.0
+  },
+  "files": {
+    "meeting_live_md": "meeting_live.md",
+    "meeting_live_jsonl": "meeting_live.jsonl",
+    "meeting_live_html": "meeting_live.html",
+    "phases_jsonl": "phases.jsonl",
+    "thoughts_jsonl": "thoughts.jsonl",
+    "control_jsonl": "control.jsonl",
+    "kpi_json": "kpi.json",
+    "metrics_csv": "metrics.csv",
+    "metrics_cpu_mem_png": "metrics_cpu_mem.png",
+    "metrics_gpu_png": "metrics_gpu.png"
+  }
 }

--- a/docs/samples/cli_baseline/chat_mode.json
+++ b/docs/samples/cli_baseline/chat_mode.json
@@ -60,7 +60,25 @@
         "meta": {}
       }
     ],
-    "final": "合意事項:\n- 空間を活かす新スポーツを実証する\n- 用具の安全確保と得点管理を両立\n残課題:\n- 動作手順の動画化で理解を補強\n直近アクション:\n- 担当:Alice が安全テストを実施 (期限:来週)\n- 担当:Bob がKPI測定を設計 (期限:来月)"
+    "final": "合意事項:\n- 空間を活かす新スポーツを実証する\n- 用具の安全確保と得点管理を両立\n残課題:\n- 動作手順の動画化で理解を補強\n直近アクション:\n- 担当:Alice が安全テストを実施 (期限:来週)\n- 担当:Bob がKPI測定を設計 (期限:来月)",
+    "kpi": {
+      "progress": 0.0,
+      "diversity": 0.6,
+      "decision_density": 1.0,
+      "spec_coverage": 1.0
+    },
+    "files": {
+      "meeting_live_md": "meeting_live.md",
+      "meeting_live_jsonl": "meeting_live.jsonl",
+      "meeting_live_html": "meeting_live.html",
+      "phases_jsonl": "phases.jsonl",
+      "thoughts_jsonl": "thoughts.jsonl",
+      "control_jsonl": "control.jsonl",
+      "kpi_json": "kpi.json",
+      "metrics_csv": "metrics.csv",
+      "metrics_cpu_mem_png": "metrics_cpu_mem.png",
+      "metrics_gpu_png": "metrics_gpu.png"
+    }
   },
   "kpi": {
     "progress": 0.0,

--- a/docs/samples/cli_baseline/legacy_flow.json
+++ b/docs/samples/cli_baseline/legacy_flow.json
@@ -60,7 +60,25 @@
         "meta": {}
       }
     ],
-    "final": "合意事項:\n- 空間を活かす新スポーツを実証する\n- 用具の安全確保と得点管理を両立\n残課題:\n- 動作手順の動画化で理解を補強\n直近アクション:\n- 担当:Alice が安全テストを実施 (期限:来週)\n- 担当:Bob がKPI測定を設計 (期限:来月)"
+    "final": "合意事項:\n- 空間を活かす新スポーツを実証する\n- 用具の安全確保と得点管理を両立\n残課題:\n- 動作手順の動画化で理解を補強\n直近アクション:\n- 担当:Alice が安全テストを実施 (期限:来週)\n- 担当:Bob がKPI測定を設計 (期限:来月)",
+    "kpi": {
+      "progress": 0.0,
+      "diversity": 0.0,
+      "decision_density": 0.0,
+      "spec_coverage": 1.0
+    },
+    "files": {
+      "meeting_live_md": "meeting_live.md",
+      "meeting_live_jsonl": "meeting_live.jsonl",
+      "meeting_live_html": "meeting_live.html",
+      "phases_jsonl": "phases.jsonl",
+      "thoughts_jsonl": "thoughts.jsonl",
+      "control_jsonl": "control.jsonl",
+      "kpi_json": "kpi.json",
+      "metrics_csv": "metrics.csv",
+      "metrics_cpu_mem_png": "metrics_cpu_mem.png",
+      "metrics_gpu_png": "metrics_gpu.png"
+    }
   },
   "kpi": {
     "progress": 0.0,


### PR DESCRIPTION
## Summary
- keep the computed KPI values available when writing meeting_result.json and expose them in a new `kpi` field
- include relative paths to generated artifacts in a new `files` dictionary so the frontend can enable downloads
- update sample outputs to reflect the enriched meeting_result.json structure

## Testing
- AI_MEETING_TEST_MODE=1 python -m backend.ai_meeting --topic "サンプル検証" --rounds 1 --precision 5 --agents Alice Bob --backend ollama --outdir logs/sample_check
- AI_MEETING_TEST_MODE=deterministic python -m backend.ai_meeting --topic "テストE2E" --agents Alice Bob --rounds 2 --precision 6 --backend ollama --no-kpi-auto-prompt --no-kpi-auto-tune --outdir /tmp/cli_baseline_chat
- AI_MEETING_TEST_MODE=deterministic python -m backend.ai_meeting --topic "E2E旧フロー" --agents Alice Bob --rounds 2 --precision 4 --backend ollama --no-think-mode --no-chat-mode --no-kpi-auto-prompt --no-kpi-auto-tune --no-resolve-round --outdir /tmp/cli_baseline_legacy
- pytest backend/tests/test_cli_e2e.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3b5c1cb4832c9ba81c78215b8b13