### PR TITLE
Encode meeting IDs in navigation routes

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -39,7 +39,8 @@ export default function Home() {
         rounds: String(roundsValue),
         agents,
       }).toString();
-      nav(`/meeting/${meetingId}?${params}`);
+      const encodedMeetingId = encodeURIComponent(meetingId);
+      nav(`/meeting/${encodedMeetingId}?${params}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/frontend/src/pages/Meeting.jsx
+++ b/frontend/src/pages/Meeting.jsx
@@ -101,7 +101,10 @@ export default function Meeting() {
     { key: "spec_coverage", label: "Spec Coverage" },
   ]), []);
 
-  const toResult = () => nav(`/result/${meetingId}`);
+  const toResult = () => {
+    const encodedMeetingId = encodeURIComponent(meetingId);
+    nav(`/result/${encodedMeetingId}`);
+  };
 
   return (
     <section className="grid-2">


### PR DESCRIPTION
## Summary
- encode meeting ID values before routing from the home page so nested paths remain intact
- encode the meeting ID when moving from the meeting page to the result page to keep routing stable

## Testing
- npm test -- --watch=false *(fails: project has no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dd428bd718832c92e2fae7205bd663