### PR TITLE
Add structured phase state tracking to meeting monitor

### DIFF
--- a/backend/ai_meeting/phase.py
+++ b/backend/ai_meeting/phase.py
@@ -1,0 +1,19 @@
+"""フェーズ状態のデータ構造を定義するモジュール。"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class PhaseState:
+    """会議フェーズの進行状況を保持する。"""
+
+    id: int
+    start_turn: int
+    turn_indices: List[int] = field(default_factory=list)
+    unresolved_counts: List[int] = field(default_factory=list)
+    status: str = "open"
+
+
+__all__ = ["PhaseState"]


### PR DESCRIPTION
## Summary
- add a PhaseState dataclass to capture per-phase progress metadata
- initialize Meeting with current/history phase storage and helpers to begin/end phases
- sync unresolved counts with the current phase state and log combined PhaseState/PhaseEvent payloads

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dd609f0284832cae68b982494c6474