### PR TITLE
Fix meeting phase initialization safety

### DIFF
--- a/backend/ai_meeting/meeting.py
+++ b/backend/ai_meeting/meeting.py
@@ -52,6 +52,7 @@ class Meeting:
         self._unresolved_history: List[int] = []
         self._phases: List[PhaseState] = []
         self._legacy_round_offset: int = 0
+        self._phase_state: Optional[PhaseState] = None
         self._phase_state = self._begin_phase(
             PhaseEvent(
                 phase_id=0,
@@ -84,7 +85,8 @@ class Meeting:
         """フェーズを開始し、現在の状態として保持する。"""
 
         phase_id = event.phase_id if event.phase_id is not None else self._phase_id
-        kind = event.kind or (self._phase_state.kind if self._phase_state else "discussion")
+        current = getattr(self, "_phase_state", None)
+        kind = event.kind or (current.kind if current else "discussion")
         state = PhaseState(
             id=phase_id,
             start_turn=event.start_turn,

--- a/backend/tests/test_phase_init.py
+++ b/backend/tests/test_phase_init.py
@@ -1,0 +1,30 @@
+"""フェーズ初期化に関するテスト。"""
+
+import pytest
+
+from backend.ai_meeting.config import AgentConfig, MeetingConfig
+from backend.ai_meeting.meeting import Meeting
+
+
+@pytest.mark.parametrize("backend_name", ["ollama"])
+def test_meeting_initial_phase_safe(tmp_path, monkeypatch, backend_name):
+    """Meeting 初期化時にフェーズ種別の参照が安全に行われることを検証する。"""
+
+    monkeypatch.setenv("AI_MEETING_TEST_MODE", "deterministic")
+    outdir = tmp_path / "phase_init"
+    cfg = MeetingConfig(
+        topic="フェーズ初期化テスト",
+        precision=5,
+        agents=[
+            AgentConfig(name="Alice", system="あなたは会議参加者です。"),
+            AgentConfig(name="Bob", system="あなたは会議参加者です。"),
+        ],
+        backend_name=backend_name,
+        phase_turn_limit={"discussion": 2},
+        outdir=str(outdir),
+    )
+
+    meeting = Meeting(cfg)
+
+    assert meeting._phase_state is not None
+    assert meeting._phase_state.kind == "discussion"


### PR DESCRIPTION
## Summary
- initialize the meeting phase state before starting the first phase
- guard phase kind resolution with a defensive lookup
- add a regression test ensuring Meeting can be constructed without phase state errors

## Testing
- PYTHONPATH=. pytest backend/tests/test_phase_init.py


------
https://chatgpt.com/codex/tasks/task_e_68de50530ab4832cacc24f5ce9c088af