### PR TITLE
Update default Ollama model to gpt-oss:20b

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Meeting(cfg).run()
    pip install pydantic psutil matplotlib pynvml GPUtil requests openai
    ```
    ※ `pynvml` や `GPUtil` は GPU 利用率を取得したいときのみ必須です。【F:backend/ai_meeting/metrics.py†L17-L93】
-2. Ollama を利用する場合は `ollama run llama3` などでローカルサーバーを立ち上げておきます (既定は `http://localhost:11434`)。【F:backend/ai_meeting/llm.py†L55-L80】
+2. Ollama を利用する場合は `ollama run gpt-oss:20b` などでローカルサーバーを立ち上げておきます (既定は `http://localhost:11434`)。【F:backend/ai_meeting/llm.py†L55-L80】
 3. OpenAI を利用する場合は `OPENAI_API_KEY` と必要なら `OPENAI_MODEL` を環境変数に設定します。【F:backend/ai_meeting/llm.py†L27-L52】
 4. 会議を実行します。例：
    ```bash

--- a/backend/ai_meeting/llm.py
+++ b/backend/ai_meeting/llm.py
@@ -57,7 +57,7 @@ class OpenAIBackend(LLMBackend):
 class OllamaBackend(LLMBackend):
     """ローカルの Ollama API を利用するバックエンド。"""
 
-    def __init__(self, model: str = "llama3", host: str = "http://127.0.0.1:11434"):
+    def __init__(self, model: str = "gpt-oss:20b", host: str = "http://127.0.0.1:11434"):
         import requests
 
         self.requests = requests

--- a/backend/ai_meeting/meeting.py
+++ b/backend/ai_meeting/meeting.py
@@ -38,7 +38,7 @@ class Meeting:
         elif cfg.backend_name == "openai":
             self.backend = OpenAIBackend(model=cfg.openai_model)
         else:
-            model = cfg.ollama_model or os.getenv("OLLAMA_MODEL", "llama3")
+            model = cfg.ollama_model or os.getenv("OLLAMA_MODEL", "gpt-oss:20b")
             host = cfg.ollama_url or os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
             self.backend = OllamaBackend(model=model, host=host)
         rp = self.cfg.runtime_params()


### PR DESCRIPTION
## Summary
- switch the Ollama default model to `gpt-oss:20b` in the meeting backend
- update the Ollama backend class to use `gpt-oss:20b` when no model is specified
- align the README setup instructions with the new default model

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5a077f60832c8d363551ceb1390b