### PR TITLE
Add summary probe configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Meeting(cfg).run()
 - `--rounds`：従来のラウンド数指定。現在は `phase_turn_limit` のエイリアスとして読み替えられ、実行時に非推奨警告が表示されます。【F:backend/ai_meeting/cli.py†L20-L206】【F:backend/ai_meeting/config.py†L30-L171】
 - `--think-mode`：思考→審査→発言 (T3→T1) のプロセスを有効化/無効化します。【F:backend/ai_meeting/config.py†L83-L85】【F:backend/ai_meeting/meeting.py†L543-L618】
 - `--outdir`：ログ出力先を明示指定。未指定なら自動で `logs/<日時_トピック>` を作成します。【F:backend/ai_meeting/config.py†L77-L78】【F:backend/ai_meeting/logging.py†L14-L44】
+- `--summary-probe` / `--summary-probe-filename`：要約プローブ用の補助JSON (`summary_probe_filename` 既定値は `summary_probe.json`) を有効化・ファイル名変更します。YAML/JSON 設定では `summary_probe_enabled: true` のように指定できます。【F:backend/ai_meeting/config.py†L79-L86】【F:backend/ai_meeting/cli.py†L53-L83】
 
 ## ログファイルの構成
 - `meeting_live.jsonl`：1 行 1 発言の JSON Lines。フロントエンドのタイムラインが参照します。【F:backend/ai_meeting/logging.py†L14-L107】【F:frontend/src/services/api.js†L17-L37】

--- a/backend/ai_meeting/cli.py
+++ b/backend/ai_meeting/cli.py
@@ -67,6 +67,17 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--chat-max-chars", type=int, default=120)
     ap.add_argument("--chat-window", type=int, default=2)
     ap.add_argument("--outdir", default=None, help="ログ出力先ディレクトリ（未指定なら自動生成）")
+    ap.add_argument(
+        "--summary-probe",
+        dest="summary_probe_enabled",
+        action="store_true",
+        help="要約プローブを有効化して補助JSONを保存（暫定機能）",
+    )
+    ap.add_argument(
+        "--summary-probe-filename",
+        default="summary_probe.json",
+        help="要約プローブの出力ファイル名（暫定）",
+    )
     # 以降のステップ用（Step 0では未使用。フラグだけ受ける）
     ap.add_argument(
         "--equilibrium",
@@ -239,6 +250,8 @@ def main() -> None:
         phase_loop_threshold=max(1, int(getattr(args, "phase_loop_threshold", 3))),
         think_mode=getattr(args, "think_mode", True),
         think_debug=getattr(args, "think_debug", True),
+        summary_probe_enabled=getattr(args, "summary_probe_enabled", False),
+        summary_probe_filename=getattr(args, "summary_probe_filename", "summary_probe.json"),
     )
     cfg.kpi_window = max(1, int(getattr(args, "kpi_window", 6)))
     cfg.kpi_auto_prompt = getattr(args, "kpi_auto_prompt", True)

--- a/backend/ai_meeting/config.py
+++ b/backend/ai_meeting/config.py
@@ -83,6 +83,8 @@ class MeetingConfig(BaseModel):
     # ---- Step8前: 思考→審査→発言（T3→T1）MVP ----
     think_mode: bool = True  # 全員が非公開の「思考」を出してから発言者を決める
     think_debug: bool = True  # thoughts.jsonl に全思考・採点を保存（本文には出さない）
+    summary_probe_enabled: bool = False  # 要約プローブ（暫定）を有効化するかどうか
+    summary_probe_filename: str = "summary_probe.json"  # 要約プローブの出力ファイル名
     # --- Step 7: KPIフィードバック制御 ---
     kpi_window: int = 6  # 直近W発言でミニKPIを算出
     kpi_auto_prompt: bool = True  # 閾値割れで隠しプロンプトを注入

--- a/backend/tests/test_config_summary_probe.py
+++ b/backend/tests/test_config_summary_probe.py
@@ -1,0 +1,46 @@
+"""MeetingConfig の要約プローブ関連フィールドに関するテスト。"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.ai_meeting.config import AgentConfig, MeetingConfig
+
+
+def _base_agents():
+    """最小構成のエージェントリストを返すヘルパー。"""
+
+    return [
+        AgentConfig(name="Alice", system="短く要点をまとめてください。"),
+        AgentConfig(name="Bob", system="短く要点をまとめてください。"),
+    ]
+
+
+def test_summary_probe_defaults_and_assignment():
+    """要約プローブ関連フィールドのデフォルトと代入を確認する。"""
+
+    cfg = MeetingConfig(topic="要約プローブの確認", agents=_base_agents())
+
+    # 既定値では無効化され、ファイル名は定数になる。
+    assert cfg.summary_probe_enabled is False
+    assert cfg.summary_probe_filename == "summary_probe.json"
+
+    # 代入時に validate_assignment が働くか確認する。
+    cfg.summary_probe_enabled = True
+    assert cfg.summary_probe_enabled is True
+
+
+def test_summary_probe_filename_validation():
+    """summary_probe_filename への不正代入が検出されることを確認する。"""
+
+    cfg = MeetingConfig(
+        topic="要約プローブのファイル名検証",
+        agents=_base_agents(),
+        summary_probe_enabled=True,
+        summary_probe_filename="custom_summary.json",
+    )
+
+    assert cfg.summary_probe_enabled is True
+    assert cfg.summary_probe_filename == "custom_summary.json"
+
+    with pytest.raises(ValidationError):
+        cfg.summary_probe_filename = 42  # type: ignore[assignment]

--- a/docs/meeting_logging.md
+++ b/docs/meeting_logging.md
@@ -5,6 +5,7 @@
 - `meeting_live.jsonl`: 各発言・要約・最終決定を `ts/type/round/turn/speaker/content` などのキーで1行JSONとして蓄積するライブログ。`type` は `"turn"`/`"summary"`/`"final"` をとる。【F:backend/ai_meeting/logging.py†L14-L139】
 - `phases.jsonl`: 監視AI（Monitor）がフェーズ確定時に書き出すメタ情報。本文には挿入せず、`cohesion` や `phase_id` に加えて `phase.goal` などのフェーズ目標も JSONL で保持する。【F:backend/ai_meeting/logging.py†L23-L70】【F:backend/ai_meeting/meeting.py†L120-L204】
 - `thoughts.jsonl`: 思考→審査フローを有効化した場合に、各ラウンドの全エージェント思考と審査結果を格納するデバッグ用ログ。【F:backend/ai_meeting/logging.py†L24-L77】【F:backend/ai_meeting/meeting.py†L297-L320】
+- `summary_probe.json`: `MeetingConfig.summary_probe_enabled` を有効化した場合に出力を予定している暫定ファイル。CLI では `--summary-probe` と `--summary-probe-filename` で制御し、YAML/JSON では `summary_probe_enabled` / `summary_probe_filename` キーで設定できるよう整備中。【F:backend/ai_meeting/config.py†L79-L86】【F:backend/ai_meeting/cli.py†L53-L83】
 - `control.jsonl`: KPIフィードバックが閾値を下回った際に自動生成される制御ログ。`type="kpi_control"` に各種指標とヒントを付与して保存する。【F:backend/ai_meeting/logging.py†L79-L84】【F:backend/ai_meeting/meeting.py†L448-L468】
 - `kpi.json`: 会議終了時のKPI指標（progress/diversity/decision_density/spec_coverage）をJSONで保存し、同時にMarkdownにも反映する。【F:backend/ai_meeting/logging.py†L128-L139】【F:backend/ai_meeting/meeting.py†L531-L537】
 - `meeting_live.html`: 将来のHTMLビューア用にパスだけ予約されているが、現状は未書き込み。`LiveLogWriter` 初期化時にファイルパスが確保される。【F:backend/ai_meeting/logging.py†L14-L43】


### PR DESCRIPTION
## Summary
- add summary_probe_enabled and summary_probe_filename fields to MeetingConfig to prepare for summary probe output
- expose CLI flags and documentation so YAML/JSON config files can set the summary probe switches
- cover the new configuration with unit tests to confirm validate_assignment continues to work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de66a82fa4832c871060e5548f1dc1