### PR TITLE
Add summary probe log handling

### DIFF
--- a/backend/ai_meeting/cli.py
+++ b/backend/ai_meeting/cli.py
@@ -77,7 +77,7 @@ def parse_args() -> argparse.Namespace:
         "--summary-probe-log",
         dest="summary_probe_log_enabled",
         action="store_true",
-        help="要約プローブ結果を毎ターンJSONLへ保存（暫定）",
+        help="要約プローブ結果（テスト要約AI）を毎ターンJSONLへ保存。summary_probe.json に記録され、他機能へは影響しない",
     )
     ap.add_argument(
         "--summary-probe-filename",

--- a/backend/ai_meeting/logging.py
+++ b/backend/ai_meeting/logging.py
@@ -12,7 +12,13 @@ from typing import Any, Dict, Optional
 class LiveLogWriter:
     """Markdown/JSONL ログを逐次追記するライター。"""
 
-    def __init__(self, topic: str, outdir: Optional[str] = None, ui_minimal: bool = True):
+    def __init__(
+        self,
+        topic: str,
+        outdir: Optional[str] = None,
+        ui_minimal: bool = True,
+        summary_probe_filename: str = "summary_probe.json",
+    ):
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         safe_topic = "".join(c if c.isalnum() or c in "-_（）()[]" else "_" for c in topic)[:80]
         base_dir = Path(outdir or f"logs/{ts}_{safe_topic}")
@@ -25,6 +31,7 @@ class LiveLogWriter:
         self.phase_log = base_dir / "phases.jsonl"
         # ★ 思考ログ（デバッグ用・本文には出さない）
         self.thoughts_log = base_dir / "thoughts.jsonl"
+        self.summary_probe_log = base_dir / summary_probe_filename
 
         # ヘッダを書いておく
         with self.md.open("w", encoding="utf-8", newline="\n") as f:
@@ -42,6 +49,7 @@ class LiveLogWriter:
         # JSONLは空ファイル作成のみ
         self.jsonl.touch()
         self.thoughts_log.touch()
+        self.summary_probe_log.touch()
 
     def append_turn(
         self,
@@ -137,11 +145,10 @@ class LiveLogWriter:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
             f.flush()
 
-    def append_summary_probe(self, payload: Dict[str, Any], filename: str) -> None:
-        """要約プローブの結果を指定ファイルへ追記する。"""
+    def append_summary_probe(self, payload: Dict[str, Any]) -> None:
+        """要約プローブの結果を JSONL 形式で追記する。"""
 
-        path = self.dir / filename
-        with path.open("a", encoding="utf-8", newline="\n") as f:
+        with self.summary_probe_log.open("a", encoding="utf-8", newline="\n") as f:
             f.write(json.dumps(payload, ensure_ascii=False) + "\n")
             f.flush()
 

--- a/backend/ai_meeting/meeting.py
+++ b/backend/ai_meeting/meeting.py
@@ -49,7 +49,12 @@ class Meeting:
         self._summary_probe_records: List[Dict[str, Any]] = []
         self._summary_probe_logger: Optional[SummaryProbe] = None
         self._pending = PendingTracker()  # 残課題トラッカー
-        self.logger = LiveLogWriter(self.cfg.topic, outdir=self.cfg.outdir, ui_minimal=self.cfg.ui_minimal)
+        self.logger = LiveLogWriter(
+            self.cfg.topic,
+            outdir=self.cfg.outdir,
+            ui_minimal=self.cfg.ui_minimal,
+            summary_probe_filename=self.cfg.summary_probe_filename,
+        )
         self.equilibrium_enabled = self.cfg.equilibrium
         self._monitor = Monitor(self.cfg) if self.cfg.monitor else None
         self._phase_id = 0
@@ -480,7 +485,7 @@ class Meeting:
                 if phase_base is not None:
                     phase_payload["base"] = phase_base
                 payload["phase"] = phase_payload
-            self.logger.append_summary_probe(payload, self.cfg.summary_probe_filename)
+            self.logger.append_summary_probe(payload)
         except Exception as exc:  # noqa: BLE001 - ログ記録では失敗を握りつぶす
             self.logger.append_warning(
                 "summary_probe_logging_failed",

--- a/docs/meeting_logging.md
+++ b/docs/meeting_logging.md
@@ -5,7 +5,7 @@
 - `meeting_live.jsonl`: 各発言・要約・最終決定を `ts/type/round/turn/speaker/content` などのキーで1行JSONとして蓄積するライブログ。`type` は `"turn"`/`"summary"`/`"final"` をとる。【F:backend/ai_meeting/logging.py†L14-L139】
 - `phases.jsonl`: 監視AI（Monitor）がフェーズ確定時に書き出すメタ情報。本文には挿入せず、`cohesion` や `phase_id` に加えて `phase.goal` などのフェーズ目標も JSONL で保持する。【F:backend/ai_meeting/logging.py†L23-L70】【F:backend/ai_meeting/meeting.py†L120-L204】
 - `thoughts.jsonl`: 思考→審査フローを有効化した場合に、各ラウンドの全エージェント思考と審査結果を格納するデバッグ用ログ。【F:backend/ai_meeting/logging.py†L24-L77】【F:backend/ai_meeting/meeting.py†L297-L320】
-- `summary_probe.json`: `MeetingConfig.summary_probe_enabled` を有効化した場合に出力を予定している暫定ファイル。CLI では `--summary-probe` と `--summary-probe-filename` で制御し、YAML/JSON では `summary_probe_enabled` / `summary_probe_filename` キーで設定できるよう整備中。【F:backend/ai_meeting/config.py†L79-L86】【F:backend/ai_meeting/cli.py†L53-L83】
+- `summary_probe.json`: `MeetingConfig.summary_probe_enabled` を有効化した場合に出力を予定している暫定ファイル。テスト要約AIが生成したログのみを JSON Lines で蓄積し、他機能へは影響しない。CLI では `--summary-probe` と `--summary-probe-filename` で制御し、YAML/JSON では `summary_probe_enabled` / `summary_probe_filename` キーで設定できるよう整備中。【F:backend/ai_meeting/config.py†L79-L86】【F:backend/ai_meeting/cli.py†L53-L83】
 - `control.jsonl`: KPIフィードバックが閾値を下回った際に自動生成される制御ログ。`type="kpi_control"` に各種指標とヒントを付与して保存する。【F:backend/ai_meeting/logging.py†L79-L84】【F:backend/ai_meeting/meeting.py†L448-L468】
 - `kpi.json`: 会議終了時のKPI指標（progress/diversity/decision_density/spec_coverage）をJSONで保存し、同時にMarkdownにも反映する。【F:backend/ai_meeting/logging.py†L128-L139】【F:backend/ai_meeting/meeting.py†L531-L537】
 - `meeting_live.html`: 将来のHTMLビューア用にパスだけ予約されているが、現状は未書き込み。`LiveLogWriter` 初期化時にファイルパスが確保される。【F:backend/ai_meeting/logging.py†L14-L43】


### PR DESCRIPTION
## Summary
- extend `LiveLogWriter` to manage a dedicated summary probe log file and append helper
- route meeting summary probe logging through the new helper so UI artifacts remain untouched
- document the CLI flag behavior noting the test summary AI log stays in `summary_probe.json`

## Testing
- PYTHONPATH=. pytest backend/tests/test_summary_probe.py backend/tests/test_config_summary_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68de73608cf4832cb0d620e5cec9a998