### PR TITLE
Refine summary probe logging

### DIFF
--- a/tests/test_summary_probe.py
+++ b/tests/test_summary_probe.py
@@ -63,5 +63,7 @@ def test_summary_probe_logging_appends_json(tmp_path, monkeypatch) -> None:
         assert len(summary_records) == expected_rounds
         assert all("summary" in rec for rec in summary_records)
         assert all(rec.get("type") != "summary_probe" for rec in live_records)
+        assert len(summary_entries) == len(summary_records)
+        assert [rec["summary"] for rec in summary_records] == [entry["summary"] for entry in summary_entries]
     finally:
         shutil.rmtree(meeting.logger.dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- have Meeting._summarize_round return the generated SummaryProbe payload for reuse
- update summary probe logging to persist the provided payload without regenerating summaries
- add an assertion ensuring the summary probe log matches meeting_live summaries

## Testing
- pytest tests/test_summary_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68de78ae5000832cae3490a36bfe0d50