### PR TITLE
Add chat summary context to agent prompts

### DIFF
--- a/backend/ai_meeting/config.py
+++ b/backend/ai_meeting/config.py
@@ -61,6 +61,7 @@ class MeetingConfig(BaseModel):
     chat_max_sentences: int = 2
     chat_max_chars: int = 120
     chat_window: int = 2  # 直近何発言を見せるか
+    chat_context_summary: bool = True  # サマリーをチャット文脈に注入するか
     # --- 以降のステップ用プレースホルダ（Step 0では未使用） ---
     equilibrium: bool = False  # 均衡AI（メタ評価）
     monitor: bool = False  # 監視AI（フェーズ検知）

--- a/backend/tests/test_meeting_judge.py
+++ b/backend/tests/test_meeting_judge.py
@@ -40,10 +40,16 @@ def _make_meeting(response: str, agent_names: Optional[List[str]] = None) -> Mee
     meeting.cfg = SimpleNamespace(
         topic="テスト",
         chat_window=2,
-        agents=[SimpleNamespace(name=name) for name in agent_names],
+        chat_mode=True,
+        chat_max_sentences=2,
+        chat_max_chars=120,
+        chat_context_summary=True,
+        agents=[SimpleNamespace(name=name, system="", style="") for name in agent_names],
     )
     meeting.history = []
     meeting.backend = _StubBackend(response)
+    meeting._conversation_summary_points = []
+    meeting._conversation_summary_text = ""
     return meeting
 
 

--- a/backend/tests/test_meeting_prompt.py
+++ b/backend/tests/test_meeting_prompt.py
@@ -13,7 +13,7 @@ from backend.ai_meeting.config import AgentConfig, MeetingConfig, Turn
 from backend.ai_meeting.meeting import Meeting
 
 
-def _build_meeting(tmp_path, monkeypatch):
+def _build_meeting(tmp_path, monkeypatch, *, chat_mode: bool = False, chat_window: int = 2):
     """テスト用の Meeting インスタンスを生成する補助関数。"""
 
     monkeypatch.setenv("AI_MEETING_TEST_MODE", "deterministic")
@@ -23,7 +23,8 @@ def _build_meeting(tmp_path, monkeypatch):
         precision=5,
         agents=[AgentConfig(name="Alice", system="あなたは会議参加者です。")],
         backend_name="ollama",
-        chat_mode=False,
+        chat_mode=chat_mode,
+        chat_window=chat_window,
         outdir=str(outdir),
     )
     return Meeting(cfg)
@@ -51,3 +52,42 @@ def test_agent_prompt_includes_last_turn_context(tmp_path, monkeypatch, last_sum
         assert req.messages[1]["content"].startswith("前ラウンド要約:")
     else:
         assert not req.messages[1]["content"].startswith("前ラウンド要約:")
+
+
+def test_agent_prompt_injects_summary_in_chat_mode(tmp_path, monkeypatch):
+    """チャットモードで会話サマリーが先頭に入ることを検証する。"""
+
+    meeting = _build_meeting(tmp_path, monkeypatch, chat_mode=True, chat_window=2)
+    agent = meeting.cfg.agents[0]
+    meeting.history = [
+        Turn(speaker="Bob", content="課題を共有する"),
+        Turn(speaker="Carol", content="対策案を示す"),
+        Turn(speaker="Dave", content="役割を確認する"),
+    ]
+    meeting._conversation_summary(new_turn=meeting.history[-1], round_summary="- 決定: 対策案を採用\n- 次: 担当と期限を整理")
+
+    req = meeting._agent_prompt(agent, last_summary="無視されるサマリー")
+
+    assert req.messages[0]["content"].startswith("会話サマリー:")
+    assert "- 決定: 対策案を採用" in req.messages[0]["content"]
+    assert req.messages[1]["content"] == f"Carol: {meeting.history[-2].content}"
+    assert req.messages[2]["content"] == f"Dave: {meeting.history[-1].content}"
+
+
+def test_agent_prompt_skips_summary_when_disabled(tmp_path, monkeypatch):
+    """サマリー注入が無効な場合は従来どおり直近発言のみになる。"""
+
+    meeting = _build_meeting(tmp_path, monkeypatch, chat_mode=True, chat_window=2)
+    meeting.cfg.chat_context_summary = False
+    agent = meeting.cfg.agents[0]
+    meeting.history = [
+        Turn(speaker="Bob", content="課題を共有する"),
+        Turn(speaker="Carol", content="対策案を示す"),
+    ]
+    meeting._conversation_summary(new_turn=meeting.history[-1], round_summary="- 決定: 対策案を採用")
+
+    req = meeting._agent_prompt(agent, last_summary="無視されるサマリー")
+
+    assert not req.messages[0]["content"].startswith("会話サマリー:")
+    assert req.messages[0]["content"] == f"Bob: {meeting.history[-2].content}"
+    assert req.messages[1]["content"] == f"Carol: {meeting.history[-1].content}"


### PR DESCRIPTION
## Summary
- add a persistent conversation summary that updates whenever new turns are recorded
- allow chat prompts to prepend the running summary when chat_context_summary is enabled
- extend prompt-related tests to cover summary injection and the opt-out path

## Testing
- pytest backend/tests/test_meeting_prompt.py backend/tests/test_meeting_judge.py

------
https://chatgpt.com/codex/tasks/task_e_68de94082500832cbb42d6e8c7015ac3