### PR TITLE
Refactor last turn handling in LLM requests

### DIFF
--- a/backend/ai_meeting/llm.py
+++ b/backend/ai_meeting/llm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 import typing
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 from urllib.parse import urlparse
 import ipaddress
 
@@ -17,7 +17,7 @@ class LLMRequest(BaseModel):
     messages: list[dict[str, str]]
     temperature: float = 0.7
     max_tokens: int = 800
-    last_turn_detail: Optional[str] = None
+    metadata: dict[str, Any] | None = None
 
 
 class LLMBackend:

--- a/backend/ai_meeting/meeting.py
+++ b/backend/ai_meeting/meeting.py
@@ -405,7 +405,11 @@ class Meeting:
             normalized = " ".join(last_turn.content.strip().split())
             if len(normalized) > 80:
                 normalized = normalized[:80] + "…"
-            last_turn_detail = f"{last_turn.speaker}: {normalized}" if normalized else f"{last_turn.speaker}: (内容なし)"
+            last_turn_detail = (
+                f"{last_turn.speaker}: {normalized}"
+                if normalized
+                else f"{last_turn.speaker}: (内容なし)"
+            )
         else:
             last_turn_detail = "直前発言なし"
         recent = self._recent_context(self.cfg.chat_window)
@@ -429,7 +433,6 @@ class Meeting:
             messages=[{"role": "user", "content": user}],
             temperature=min(0.9, self.temperature + 0.1),
             max_tokens=120,
-            last_turn_detail=last_turn_detail,
         )
         return self._enforce_chat_constraints(self.backend.generate(req)).strip()
 

--- a/backend/tests/test_meeting_think.py
+++ b/backend/tests/test_meeting_think.py
@@ -48,8 +48,8 @@ def test_think_prompt_focuses_on_last_speaker(tmp_path, monkeypatch):
     assert "Bob" in result  # 応答方針に相手の名前が含まれていること
 
     req = captured["req"]
-    assert req.last_turn_detail == "Bob: 議論の現状を整理したので、次は役割分担を決めたい。"
-    assert "last_turn_detail: Bob:" in req.messages[0]["content"]
+    user_prompt = req.messages[0]["content"]
+    assert "last_turn_detail: Bob: 議論の現状を整理したので、次は役割分担を決めたい。" in user_prompt
     assert "前回の発言者（名前）への応答方針を1文でまとめ、必要なら次の質問を用意する。" in req.messages[0]["content"]
 
 


### PR DESCRIPTION
## Summary
- replace the dedicated last_turn_detail field on LLMRequest with a generic metadata slot
- stop populating last_turn_detail in Meeting._think and rely on the user prompt for context
- update meeting think unit test to assert against the prompt content instead of the removed field

## Testing
- pytest backend/tests/test_meeting_think.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb37078e8832c8c3d44450eb11411