### PR TITLE
Refactor meeting summary handling and expose log iterators

### DIFF
--- a/backend/tests/test_meeting_judge.py
+++ b/backend/tests/test_meeting_judge.py
@@ -49,7 +49,6 @@ def _make_meeting(response: str, agent_names: Optional[List[str]] = None) -> Mee
     meeting.history = []
     meeting.backend = _StubBackend(response)
     meeting._conversation_summary_points = []
-    meeting._conversation_summary_text = ""
     return meeting
 
 
@@ -146,7 +145,6 @@ def test_judge_thoughts_prompt_includes_summaries() -> None:
     meeting = _make_meeting("{}", ["Alice"])
     meeting.history = [SimpleNamespace(speaker="Alice", content="こんにちは")]
     meeting._conversation_summary_points = ["Alice: こんにちは"]
-    meeting._conversation_summary_text = "- Alice: こんにちは"
     last_summary = "前回のまとめ"
     flow_summary = meeting._conversation_summary()
 

--- a/tests/test_summary_probe.py
+++ b/tests/test_summary_probe.py
@@ -44,13 +44,7 @@ def test_summary_probe_logging_appends_json(tmp_path, monkeypatch) -> None:
     try:
         meeting.run()
         log_dir = meeting.logger.dir
-        summary_path = log_dir / cfg.summary_probe_filename
-
-        summary_entries = [
-            json.loads(line)
-            for line in summary_path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
+        summary_entries = list(meeting.logger.iter_summary_probe())
         assert summary_entries, "summary_probe ログに JSON エントリが存在すること"
 
         live_records = [


### PR DESCRIPTION
## Summary
- remove in-memory caching of conversation summaries in `Meeting` and derive the bullet text directly from stored points
- drop unused `_summary_probe_records` state and add a convenience iterator on `LiveLogWriter` to read summary probe logs
- extend prompt-related tests to cover the new summary string generation and update existing summary probe logging tests

## Testing
- `pytest backend/tests/test_meeting_prompt.py backend/tests/test_meeting_judge.py tests/test_summary_probe.py`


------
https://chatgpt.com/codex/tasks/task_e_68dfb4f7df40832c932c8bfe7a0acc1f