### PR TITLE
feat: add prioritized agent memory metadata

### DIFF
--- a/backend/tests/test_meeting_think.py
+++ b/backend/tests/test_meeting_think.py
@@ -59,7 +59,9 @@ def test_think_prompt_includes_agent_memory(tmp_path, monkeypatch):
     meeting = _build_meeting(tmp_path, monkeypatch)
     meeting._assign_personalities()
     agent = meeting.cfg.agents[0]
-    meeting._agent_memory[agent.name].append("重要顧客との約束を最優先で守る")
+    meeting._agent_memory[agent.name].append(
+        meeting._create_memory_entry("重要顧客との約束を最優先で守る", category="info")
+    )
 
     captured = {}
 

--- a/tests/test_failure_handling.py
+++ b/tests/test_failure_handling.py
@@ -77,7 +77,7 @@ def test_record_agent_memory_skips_invalid_summary(monkeypatch: pytest.MonkeyPat
         meeting._record_agent_memory(["Alice"], {"summary": ["誤った形式"]}, speaker_name="Alice")
 
         memory = meeting._agent_memory.get("Alice")
-        assert memory and memory[-1] == "正しい発言"
+        assert memory and memory[-1].text == "正しい発言"
 
         warnings = _read_warnings(meeting.logger.jsonl)
         assert warnings, "agent_memory_invalid_summary_text の警告が出力されること"


### PR DESCRIPTION
## Summary
- add structured metadata for agent memories, including category, priority, and timestamp tracking
- update memory recording to score entries and evict low-priority items when limits are reached
- expand meeting memory tests to cover priority-based retention and adjust existing checks

## Testing
- pytest backend/tests tests/test_failure_handling.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc40d6004832cbab549f881f9b605