### PR TITLE
Add log channel toggles and regression test for meeting_result metadata

### DIFF
--- a/backend/ai_meeting/config.py
+++ b/backend/ai_meeting/config.py
@@ -70,6 +70,8 @@ class MeetingConfig(BaseModel):
     shock_ttl: int = 2  # ショックを維持するターン数（フェーズ確定後の有効ターン）
     # --- Step 1: UI最小化（台本感を消す表示） ---
     ui_minimal: bool = True  # 役職やRound見出しを出さない
+    log_markdown_enabled: bool = True  # meeting_live.md を生成するかどうか
+    log_jsonl_enabled: bool = True  # meeting_live.jsonl を生成するかどうか
     # --- Step 3: 多様性＆独占ガード ---
     cooldown: float = 0.10  # 直近発言者への減点（0.0-1.0）
     cooldown_span: int = 1  # 何ターン遡ってクールダウンを適用するか

--- a/tests/test_meeting_result_metadata.py
+++ b/tests/test_meeting_result_metadata.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.ai_meeting.config import AgentConfig, MeetingConfig  # noqa: E402
+from backend.ai_meeting.meeting import Meeting  # noqa: E402
+
+
+def _create_config(outdir: Path) -> MeetingConfig:
+    """ログチャネル切り替え検証用の設定を生成する。"""
+
+    return MeetingConfig(
+        topic="ログチャネル出力の回帰テスト",
+        agents=[
+            AgentConfig(name="Alice", system="論点をまとめる"),
+            AgentConfig(name="Bob", system="補足視点を出す"),
+        ],
+        phase_turn_limit=1,
+        resolve_round=False,
+        think_debug=False,
+        log_markdown_enabled=False,
+        log_jsonl_enabled=True,
+        outdir=str(outdir),
+    )
+
+
+def test_meeting_result_retains_required_metadata(tmp_path, monkeypatch) -> None:
+    """meeting_result.json に必要なメタ情報が残ることを確認する。"""
+
+    monkeypatch.setenv("AI_MEETING_TEST_MODE", "1")
+    outdir = tmp_path / "logs"
+    cfg = _create_config(outdir)
+    meeting = Meeting(cfg)
+
+    try:
+        meeting.run()
+        log_dir = meeting.logger.dir
+        result_path = log_dir / "meeting_result.json"
+        assert result_path.exists(), "meeting_result.json が生成されていること"
+
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+        files = data.get("files", {})
+
+        assert "meeting_live_jsonl" in files, "JSONL ログのメタ情報が保持されていること"
+        assert files["meeting_live_jsonl"] == "meeting_live.jsonl"
+        assert "meeting_live_md" not in files, "Markdown ログを無効化した場合はメタ情報が含まれないこと"
+        assert not (log_dir / "meeting_live.md").exists(), "無効化した Markdown ログファイルが生成されていないこと"
+    finally:
+        shutil.rmtree(meeting.logger.dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add configuration flags to toggle Markdown/JSONL live log outputs and centralize LiveLogWriter record creation
- update Meeting to respect the new log channel settings and adjust meeting_result metadata emission accordingly
- add a regression test to ensure meeting_result.json keeps the required file metadata when Markdown logging is disabled

## Testing
- PYTHONPATH=. pytest tests/test_summary_probe_logging.py tests/test_meeting_result_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68dfca2a0808832cb4fb57ce1289186e