### PR TITLE
feat: enhance meeting form with model selection

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,15 +1,63 @@
-import { useState } from "react";
+import { useEffect, useMemo, useReducer, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { startMeeting } from "../services/api";
+import { getModels, startMeeting } from "../services/api";
 
 export default function Home() {
   const nav = useNavigate();
-  const [topic, setTopic] = useState("");
-  const [precision, setPrecision] = useState(5);
-  const [rounds, setRounds] = useState(4);
-  const [agents, setAgents] = useState("Alice Bob Carol");
+  const openaiConfigured = useMemo(() => Boolean(import.meta.env.VITE_OPENAI_API_KEY), []);
+  const [modelOptions, setModelOptions] = useState([]);
+  const [modelsError, setModelsError] = useState("");
+  const [formState, dispatch] = useReducer(
+    (state, action) => {
+      switch (action.type) {
+        case "update":
+          return { ...state, [action.field]: action.value };
+        case "setBackend":
+          return {
+            ...state,
+            backend: action.value,
+            model: "",
+            openaiKeyRequired: action.value === "openai" && !action.openaiConfigured,
+          };
+        case "setModel":
+          return { ...state, model: action.value };
+        default:
+          return state;
+      }
+    },
+    {
+      topic: "",
+      precision: "5",
+      rounds: "4",
+      agents: "Alice Bob Carol",
+      backend: "ollama",
+      model: "",
+      openaiKeyRequired: false,
+    },
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        const list = await getModels();
+        if (!ignore) {
+          setModelOptions(list);
+          setModelsError(list.length === 0 ? "Ollama からモデルを取得できませんでした。" : "");
+        }
+      } catch (err) {
+        if (!ignore) {
+          setModelOptions([]);
+          setModelsError(err instanceof Error ? err.message : "モデル一覧の取得に失敗しました。");
+        }
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -17,14 +65,27 @@ export default function Home() {
     setError("");
     setLoading(true);
     try {
-      const precisionValue = Number(precision) || 5;
-      const roundsValue = Number(rounds) || 4;
+      const trimmedTopic = formState.topic.trim();
+      if (!trimmedTopic) {
+        throw new Error("テーマを入力してください。");
+      }
+      const precisionValueRaw = Number(formState.precision);
+      const roundsValueRaw = Number(formState.rounds);
+      const precisionValue = Number.isFinite(precisionValueRaw) ? precisionValueRaw : undefined;
+      const roundsValue = Number.isFinite(roundsValueRaw) ? roundsValueRaw : undefined;
+      const agentsTrimmed = formState.agents.trim();
+      const backendTrimmed = formState.backend.trim();
+      const modelTrimmed = formState.model.trim();
+
       const payload = {
-        topic: topic.trim(),
+        topic: trimmedTopic,
         precision: precisionValue,
         rounds: roundsValue,
-        agents: agents.trim(),
-        backend: "ollama",
+        agents: agentsTrimmed || undefined,
+        options: {
+          llmBackend: backendTrimmed || undefined,
+          model: modelTrimmed || undefined,
+        },
       };
       const data = await startMeeting(payload);
       const outdir = typeof data.outdir === "string" ? data.outdir.replace(/\\/g, "/") : "";
@@ -34,10 +95,10 @@ export default function Home() {
         throw new Error("会議IDの取得に失敗しました。");
       }
       const params = new URLSearchParams({
-        topic,
-        precision: String(precisionValue),
-        rounds: String(roundsValue),
-        agents,
+        topic: trimmedTopic,
+        precision: String(precisionValue ?? 5),
+        rounds: String(roundsValue ?? 4),
+        agents: agentsTrimmed,
       }).toString();
       const encodedMeetingId = encodeURIComponent(meetingId);
       nav(`/meeting/${encodedMeetingId}?${params}`);
@@ -55,27 +116,68 @@ export default function Home() {
       <form className="form" onSubmit={onSubmit}>
         <label className="label">
           テーマ
-          <input className="input" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="例: 10分で遊べる1畳スポーツの仕様" required />
+          <input className="input" value={formState.topic} onChange={(e) => dispatch({ type: "update", field: "topic", value: e.target.value })} placeholder="例: 10分で遊べる1畳スポーツの仕様" required />
         </label>
 
         <div className="grid-2">
           <label className="label">
             精密度 (1-10)
-            <input className="input" type="number" min={1} max={10} value={precision} onChange={(e) => setPrecision(e.target.value)} />
+            <input className="input" type="number" min={1} max={10} value={formState.precision} onChange={(e) => dispatch({ type: "update", field: "precision", value: e.target.value })} />
           </label>
           <label className="label">
             ラウンド数
-            <input className="input" type="number" min={1} max={12} value={rounds} onChange={(e) => setRounds(e.target.value)} />
+            <input className="input" type="number" min={1} max={12} value={formState.rounds} onChange={(e) => dispatch({ type: "update", field: "rounds", value: e.target.value })} />
           </label>
         </div>
 
         <label className="label">
           参加者名（空白区切り、例: Alice Bob Carol)
-          <input className="input" value={agents} onChange={(e) => setAgents(e.target.value)} placeholder="Alice Bob Carol" />
+          <input className="input" value={formState.agents} onChange={(e) => dispatch({ type: "update", field: "agents", value: e.target.value })} placeholder="Alice Bob Carol" />
         </label>
 
+        <div className="grid-2">
+          <label className="label">
+            バックエンド
+            <select
+              className="select"
+              value={formState.backend}
+              onChange={(e) => dispatch({ type: "setBackend", value: e.target.value, openaiConfigured })}
+            >
+              <option value="ollama">Ollama (ローカル)</option>
+              <option value="openai">OpenAI API</option>
+            </select>
+            <div className="hint">利用するLLMサービスを選択します。</div>
+            {formState.openaiKeyRequired && (
+              <div className="hint error">OpenAI バックエンドを利用するには環境変数 VITE_OPENAI_API_KEY を設定してください。</div>
+            )}
+          </label>
+          <label className="label">
+            モデル
+            <select
+              className="select"
+              value={formState.model}
+              onChange={(e) => dispatch({ type: "setModel", value: e.target.value })}
+              disabled={formState.backend === "ollama" && modelOptions.length === 0}
+            >
+              <option value="">自動（バックエンド既定）</option>
+              {(formState.backend === "openai" ? OPENAI_MODEL_CHOICES : modelOptions).map((name) => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+            {formState.backend === "ollama" && modelsError && (
+              <div className="hint error">{modelsError}</div>
+            )}
+            {formState.backend === "ollama" && !modelsError && (
+              <div className="hint">Ollama にインストール済みのモデル一覧から選択できます。</div>
+            )}
+            {formState.backend === "openai" && (
+              <div className="hint">OpenAI モデルは必要に応じて選択してください。未選択時は既定値を利用します。</div>
+            )}
+          </label>
+        </div>
+
         <div className="actions">
-          <button className="btn" type="submit" disabled={!topic.trim() || loading}>
+          <button className="btn" type="submit" disabled={!formState.topic.trim() || loading || formState.openaiKeyRequired}>
             {loading ? "起動中..." : "会議を開始"}
           </button>
         </div>
@@ -84,3 +186,11 @@ export default function Home() {
     </section>
   );
 }
+
+const OPENAI_MODEL_CHOICES = [
+  "gpt-4o-mini",
+  "gpt-4o",
+  "gpt-4.1-mini",
+  "o3-mini",
+  "o1-mini",
+];

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -195,3 +195,25 @@ export async function startMeeting(payload) {
   }
   return res.json();
 }
+
+export async function getModels() {
+  const res = await fetch(withCacheBuster("/api/models"), {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`fetch failed: ${res.status} /api/models`);
+  }
+  const payload = await res.json();
+  const list = Array.isArray(payload?.models) ? payload.models : Array.isArray(payload) ? payload : [];
+  return list
+    .map((item) => {
+      if (!item) return null;
+      if (typeof item === "string") return item;
+      if (typeof item.name === "string" && item.name.trim()) return item.name;
+      if (typeof item.model === "string" && item.model.trim()) return item.model;
+      if (typeof item.id === "string" && item.id.trim()) return item.id;
+      return null;
+    })
+    .filter((name, index, arr) => Boolean(name) && arr.indexOf(name) === index)
+    .sort((a, b) => a.localeCompare(b));
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,6 +12,8 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:16px;margin-bottom:16px;box-shadow:0 1px 10px rgba(0,0,0,.15)}
 .form .label{display:block;margin:12px 0}
 .input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--border);background:#0d0e13;color:var(--text)}
+.select{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--border);background:#0d0e13;color:var(--text);appearance:none}
+.select:disabled{opacity:.6;cursor:not-allowed}
 .grid-2{display:grid;grid-template-columns:1.2fr .8fr;gap:16px}
 .row-between{display:flex;align-items:center;justify-content:space-between}
 .badge{padding:4px 10px;border-radius:999px;font-size:12px;border:1px solid var(--border)}
@@ -29,6 +31,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .btn.ghost{background:transparent;border:1px solid var(--border);color:var(--text)}
 .muted{color:var(--muted);font-size:13px;margin-top:2px}
 .hint{color:var(--muted);font-size:12px;margin-top:8px}
+.hint.error{color:#ff9a9a}
 .kpi-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
 .kpi-grid.inline{margin-top:12px}
 .kpi{background:#0d0e13;border:1px solid var(--border);border-radius:12px;padding:12px}


### PR DESCRIPTION
## Summary
- refactor the meeting creation form to use a reducer while exposing backend, model, and OpenAIキー有無の状態
- fetch available Ollama models via a new `/api/models` helper and surface them in the model select box
- send the updated meeting payload with llm options and tweak shared styles for the new controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e015938de8832cb7663e301fd13db1