### PR TITLE
高度な会議設定のサポートを追加

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -37,4 +37,15 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .kpi{background:#0d0e13;border:1px solid var(--border);border-radius:12px;padding:12px}
 .kpi-label{color:var(--muted);font-size:12px;margin-bottom:4px}
 .kpi-value{font-size:20px;font-weight:700}
+details.advanced{margin-top:16px;border-top:1px solid var(--border);padding-top:16px}
+details.advanced summary{cursor:pointer;font-weight:600;color:var(--muted);outline:none}
+.advanced-summary{list-style:none;font-size:16px}
+details.advanced[open] summary{color:var(--text)}
+details.advanced summary:focus-visible{outline:2px solid var(--brand);outline-offset:4px}
+.advanced-content{margin-top:12px}
+.advanced-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+.advanced-chat-section{display:flex;flex-direction:column;gap:8px}
+.advanced-chat-title{font-size:14px;font-weight:600}
+.advanced-chat-toggle{display:flex;align-items:center;gap:8px;font-size:14px}
+.advanced-chat-toggle input{width:auto}
 @media (max-width:900px){.grid-2{grid-template-columns:1fr}}


### PR DESCRIPTION
## Summary
- StartMeetingIn に flow/chat/memory オプションを追加し、CLI 引数への変換ロジックを整理
- フロントエンドに「高度な設定」セクションを実装して入力値を検証・正規化して送信
- 高度な設定を指定した場合に期待通りの CLI 引数が生成されることを確認するテストを追加

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e018797818832c94b4431a760288b7