### PR TITLE
Add participant editor and preset persistence

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -241,6 +241,20 @@ def _build_cli_command(
     if not agents:
         raise HTTPException(status_code=400, detail="agents must not be empty")
 
+    validated_agents: List[str] = []
+    for token in agents:
+        if token is None:
+            continue
+        value = token.strip()
+        if not value:
+            raise HTTPException(status_code=400, detail="agent names must not be empty")
+        name_part = value.split("=", 1)[0].strip()
+        if not name_part:
+            raise HTTPException(status_code=400, detail="agent names must not be empty")
+        validated_agents.append(value)
+
+    agents = validated_agents
+
     options = body.options or StartMeetingOptions()
     llm_from_options = options.llm
     llm_from_body = body.llm

--- a/backend/tests/test_app_start_meeting.py
+++ b/backend/tests/test_app_start_meeting.py
@@ -161,3 +161,23 @@ def test_start_meeting_cmd_accepts_advanced_options(monkeypatch, tmp_path):
         index = cmd_list.index(flag)
         assert cmd_list[index + 1] == expected
     assert "--no-chat-mode" in cmd_list
+
+
+def test_start_meeting_rejects_empty_agent_name(monkeypatch, tmp_path):
+    store: dict = {}
+    _setup_popen(monkeypatch, store)
+    monkeypatch.setattr(app_module, "_processes", {})
+
+    with TestClient(app_module.app) as client:
+        response = client.post(
+            "/meetings",
+            json={
+                "topic": "空の名前",  # noqa: RU002 - テストデータ
+                "agents": '"" Bob',
+                "outdir": str(tmp_path / "invalid"),
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "agent names must not be empty"
+    assert "cmd_list" not in store

--- a/frontend/src/services/presets.js
+++ b/frontend/src/services/presets.js
@@ -1,0 +1,47 @@
+// frontend/src/services/presets.js
+// 会議作成フォームのプリセットをローカルストレージへ保存・取得するユーティリティ。
+
+const STORAGE_KEY = "ai-meeting:preset:v1";
+
+function isBrowserStorageAvailable() {
+  try {
+    return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+  } catch (err) {
+    return false;
+  }
+}
+
+function safeParse(jsonText) {
+  try {
+    return JSON.parse(jsonText);
+  } catch (err) {
+    return null;
+  }
+}
+
+export function loadHomePreset() {
+  if (!isBrowserStorageAvailable()) return null;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  const data = safeParse(raw);
+  if (!data || typeof data !== "object") return null;
+  return data;
+}
+
+export function saveHomePreset(preset) {
+  if (!isBrowserStorageAvailable()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preset));
+  } catch (err) {
+    // 保存に失敗してもアプリの動作には影響させない
+  }
+}
+
+export function clearHomePreset() {
+  if (!isBrowserStorageAvailable()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (err) {
+    // noop
+  }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -48,4 +48,24 @@ details.advanced summary:focus-visible{outline:2px solid var(--brand);outline-of
 .advanced-chat-title{font-size:14px;font-weight:600}
 .advanced-chat-toggle{display:flex;align-items:center;gap:8px;font-size:14px}
 .advanced-chat-toggle input{width:auto}
+.participant-section{display:flex;flex-direction:column;gap:8px}
+.participant-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.participants-wrapper{border:1px solid var(--border);border-radius:10px;overflow-x:auto;background:#0d0e13}
+.participants-table{width:100%;border-collapse:collapse;min-width:100%}
+.participants-table th,.participants-table td{padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.08);text-align:left;vertical-align:top}
+.participants-table th{font-weight:600;font-size:13px;color:var(--muted)}
+.participants-table tr:last-child td{border-bottom:none}
+.participant-col-index{width:40px}
+.participant-col-actions{width:120px;text-align:center}
+.participant-index{text-align:center;color:var(--muted);font-size:13px}
+.participant-actions{text-align:center}
+.participant-remove{background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:8px;padding:6px 12px;cursor:pointer}
+.participant-remove:hover{color:var(--text);border-color:var(--text)}
+.participant-remove:disabled{opacity:.5;cursor:not-allowed}
+.participant-prompt{min-height:52px;resize:vertical}
+.participants-empty{border:1px dashed var(--border);border-radius:10px;padding:16px;text-align:center;background:#0d0e13;color:var(--muted)}
+.participants-empty-text{margin-bottom:8px}
+.participant-empty-add{background:transparent;border:1px solid var(--border);color:var(--text);border-radius:8px;padding:8px 14px;cursor:pointer}
+.participant-empty-add:hover{border-color:var(--text)}
+.participant-preview{display:inline-block;margin-left:4px;padding:2px 6px;border-radius:6px;border:1px solid var(--border);background:#0d0e13;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:12px}
 @media (max-width:900px){.grid-2{grid-template-columns:1fr}}


### PR DESCRIPTION
## Summary
- refactor the meeting creation page to edit participants in a table with per-agent prompts and persist presets
- add localStorage utilities to restore saved meeting form settings
- validate empty agent names in start_meeting and cover with a regression test

## Testing
- pytest backend/tests/test_app_start_meeting.py

------
https://chatgpt.com/codex/tasks/task_e_68e01bf82298832cbe3be82ce6515da6