### PR TITLE
Handle single quotes in agent token quoting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.3",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^2.1.6"
   }
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -683,10 +683,12 @@ function createAgentToken(participant) {
 }
 
 function needsQuoting(value) {
-  return /[\s"]/u.test(value);
+  return /[\s"']/u.test(value);
 }
 
 function quoteToken(value) {
   const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `"${escaped}"`;
 }
+
+export { createAgentToken, needsQuoting, quoteToken };

--- a/frontend/src/pages/__tests__/Home.test.jsx
+++ b/frontend/src/pages/__tests__/Home.test.jsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createAgentToken, quoteToken } from "../Home.jsx";
+
+describe("createAgentToken", () => {
+  it("シングルクォートを含む名前を引用する", () => {
+    const participant = { name: "O'Brien" };
+    expect(createAgentToken(participant)).toBe('"O\'Brien"');
+  });
+
+  it("シングルクォート入り名前とプロンプトを引用する", () => {
+    const participant = {
+      name: "O'Brien",
+      prompt: "討論を先導する",
+    };
+    expect(createAgentToken(participant)).toBe('"O\'Brien=討論を先導する"');
+  });
+});
+
+describe("quoteToken", () => {
+  it("バックスラッシュとダブルクォートのみをエスケープする", () => {
+    const value = 'path\\to\\"file"';
+    expect(quoteToken(value)).toBe('"path\\\\to\\\\\"file\""');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure agent tokens containing single quotes are quoted by extending the regex used in `needsQuoting`
- export the token helpers and add Vitest unit tests that cover single-quote names and prompt combinations
- wire up the frontend test script to run Vitest

## Testing
- not run (環境の制約により npm install/vitest を実行できず)


------
https://chatgpt.com/codex/tasks/task_e_68e0ffe7c610832c93495704fd0ba4ce