### PR TITLE
Remove agents text input from Home preset flow

### DIFF
--- a/frontend/src/pages/__tests__/Home.test.jsx
+++ b/frontend/src/pages/__tests__/Home.test.jsx
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { createAgentToken, quoteToken } from "../Home.jsx";
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import Home, { createAgentToken, quoteToken } from "../Home.jsx";
+import * as api from "../../services/api";
+import * as presets from "../../services/presets";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("createAgentToken", () => {
   it("シングルクォートを含む名前を引用する", () => {
@@ -22,3 +31,83 @@ describe("quoteToken", () => {
     expect(quoteToken(value)).toBe('"path\\\\to\\\\\"file\""');
   });
 });
+
+describe("Home", () => {
+  it("プリセットから参加者が復元され、エージェント文字列が専用フォームの値のみで構築される", async () => {
+    const presetParticipants = [
+      { name: "Leader", prompt: "Lead discussion" },
+      { name: "Recorder", prompt: "Take notes" },
+    ];
+
+    vi.spyOn(api, "getModels").mockResolvedValue([]);
+    const startMeetingMock = vi.spyOn(api, "startMeeting").mockResolvedValue({ id: "meeting-123" });
+    vi.spyOn(presets, "loadHomePreset").mockReturnValue({
+      form: {
+        topic: "Preset Topic",
+        precision: "6",
+        rounds: "2",
+      },
+      participants: presetParticipants,
+    });
+    vi.spyOn(presets, "saveHomePreset").mockImplementation(() => {});
+
+    const { container, unmount } = await renderWithRouter(<Home />);
+
+    await flushEffects();
+
+    const topicInput = container.querySelector('input[value="Preset Topic"]');
+    expect(topicInput).not.toBeNull();
+    const leaderInput = container.querySelector('input[value="Leader"]');
+    expect(leaderInput).not.toBeNull();
+    const promptFields = Array.from(container.querySelectorAll('textarea[class~="participant-prompt"]'));
+    expect(promptFields.length).toBe(2);
+    expect(promptFields[0]?.value).toBe("Lead discussion");
+    expect(promptFields[1]?.value).toBe("Take notes");
+    expect(container.textContent).not.toContain("追加の参加者指定（文字列入力）");
+
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+    await submitReactForm(form);
+
+    expect(startMeetingMock).toHaveBeenCalledTimes(1);
+
+    const payload = startMeetingMock.mock.calls[0][0];
+    expect(payload.agents).toBe('"Leader=Lead discussion" "Recorder=Take notes"');
+
+    unmount();
+  });
+});
+
+async function renderWithRouter(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<MemoryRouter>{ui}</MemoryRouter>);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function submitReactForm(form) {
+  await act(async () => {
+    const event = new Event("submit", { bubbles: true, cancelable: true });
+    form.dispatchEvent(event);
+  });
+  await flushEffects();
+}


### PR DESCRIPTION
## Summary
- remove the legacy free-form agents text field from the Home page and preset persistence
- simplify agent string construction and participant hydration to rely solely on the structured participant editor
- add a regression test that renders the Home page to ensure presets restore participants and submissions build the agent string correctly

## Testing
- npm test *(fails: `vitest` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e100ad49e4832cbdb7c6977c41b6b9