### PR TITLE
Update GPU metrics backend detection to prefer nvidia-ml-py

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 httpx==0.27.2
 python-dotenv==1.0.1
+nvidia-ml-py==12.535.133


### PR DESCRIPTION
## Summary
- prefer the `nvidia-ml-py` nvml bindings for GPU metrics and reuse the same API surface when falling back to pynvml
- only fall back to GPUtil when neither NVML module is available
- document the new dependency by adding nvidia-ml-py to backend requirements

## Testing
- python -m backend.ai_meeting --help

------
https://chatgpt.com/codex/tasks/task_e_68e11cc3ac18832c9414ebd7d61dbffa