### PR TITLE
Add safe console print helper

### DIFF
--- a/backend/ai_meeting/utils.py
+++ b/backend/ai_meeting/utils.py
@@ -1,6 +1,26 @@
 """`backend.ai_meeting` 内で利用する共通ユーティリティ関数群。"""
 from __future__ import annotations
 
+import sys
+from typing import Final
+
+
+_DEFAULT_ENCODING: Final[str] = "utf-8"
+
+
+def safe_console_print(text: str) -> None:
+    """コンソールのエンコーディングに合わせて安全に文字列を出力する。"""
+
+    encoding = getattr(sys.stdout, "encoding", None) or _DEFAULT_ENCODING
+    errors = "backslashreplace"
+    try:
+        processed = text.encode(encoding, errors=errors).decode(encoding, errors=errors)
+    except LookupError:
+        processed = text.encode(_DEFAULT_ENCODING, errors=errors).decode(
+            _DEFAULT_ENCODING, errors=errors
+        )
+    print(processed)
+
 
 def clamp(value: float, lower: float, upper: float) -> float:
     """値を下限・上限で挟み込んで返す。"""
@@ -11,9 +31,9 @@ def clamp(value: float, lower: float, upper: float) -> float:
 def banner(title: str) -> None:
     """シンプルな区切り線付きタイトルを出力する。"""
 
-    print("\n" + "=" * 80)
-    print(title)
-    print("=" * 80 + "\n")
+    safe_console_print("\n" + "=" * 80)
+    safe_console_print(title)
+    safe_console_print("=" * 80 + "\n")
 
 
-__all__ = ["clamp", "banner"]
+__all__ = ["clamp", "banner", "safe_console_print"]


### PR DESCRIPTION
## Summary
- safe_console_print ヘルパーを追加し、コンソールのエンコーディングに合わせて安全に出力できるようにしました
- banner と Meeting.run の標準出力をヘルパー経由に置き換え、UI モードに応じた整形を維持しました

## Testing
- PYTHONIOENCODING=cp932 PYTHONPATH=ai_meeting python - <<'PY'
from backend.ai_meeting.utils import safe_console_print
import sys

print(sys.stdout.encoding)
safe_console_print('Narrow\u202fNo-Break Space: \u202f')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e128bfd4f0832cbe3fa5a6f7146362