### PR TITLE
Add slider controls for numeric settings on home page

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -56,6 +56,10 @@ export default function Home() {
   const [participants, setParticipants] = useState(defaultParticipants);
   const [presetLoaded, setPresetLoaded] = useState(false);
 
+  const resolvedMaxPhasesValue = formState.maxPhases === "" ? "1" : formState.maxPhases;
+  const resolvedChatMaxSentencesValue =
+    formState.chatMaxSentences === "" ? "2" : formState.chatMaxSentences;
+
   const handleParticipantChange = (id, field, value) => {
     setParticipants((prev) => prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
   };
@@ -299,11 +303,33 @@ export default function Home() {
         <div className="grid-2">
           <label className="label">
             精密度 (1-10)
-            <input className="input" type="number" min={1} max={10} value={formState.precision} onChange={(e) => dispatch({ type: "update", field: "precision", value: e.target.value })} />
+            <div className="slider-control">
+              <input
+                className="range-input"
+                type="range"
+                min={1}
+                max={10}
+                step={1}
+                value={formState.precision}
+                onChange={(e) => dispatch({ type: "update", field: "precision", value: e.target.value })}
+              />
+              <span className="slider-value">{formState.precision}</span>
+            </div>
           </label>
           <label className="label">
             ラウンド数
-            <input className="input" type="number" min={1} max={12} value={formState.rounds} onChange={(e) => dispatch({ type: "update", field: "rounds", value: e.target.value })} />
+            <div className="slider-control">
+              <input
+                className="range-input"
+                type="range"
+                min={1}
+                max={12}
+                step={1}
+                value={formState.rounds}
+                onChange={(e) => dispatch({ type: "update", field: "rounds", value: e.target.value })}
+              />
+              <span className="slider-value">{formState.rounds}</span>
+            </div>
           </label>
         </div>
 
@@ -390,15 +416,26 @@ export default function Home() {
 
               <label className="label">
                 フェーズ数の上限
-                <input
-                  className="input"
-                  type="number"
-                  min={1}
-                  max={10}
-                  value={formState.maxPhases}
-                  onChange={(e) => dispatch({ type: "update", field: "maxPhases", value: e.target.value })}
-                  placeholder="未設定"
-                />
+                <div className="slider-control">
+                  <input
+                    className="range-input"
+                    type="range"
+                    min={1}
+                    max={10}
+                    step={1}
+                    value={resolvedMaxPhasesValue}
+                    onChange={(e) => dispatch({ type: "update", field: "maxPhases", value: e.target.value })}
+                  />
+                  <span className="slider-value">{formState.maxPhases || "未設定"}</span>
+                  <button
+                    type="button"
+                    className="slider-reset"
+                    onClick={() => dispatch({ type: "update", field: "maxPhases", value: "" })}
+                    disabled={formState.maxPhases === ""}
+                  >
+                    クリア
+                  </button>
+                </div>
                 <div className="hint">1〜10 の範囲で指定できます。空欄にすると自動判定に任せます。</div>
               </label>
 
@@ -417,15 +454,26 @@ export default function Home() {
 
               <label className="label">
                 チャット最大文数
-                <input
-                  className="input"
-                  type="number"
-                  min={1}
-                  max={6}
-                  value={formState.chatMaxSentences}
-                  onChange={(e) => dispatch({ type: "update", field: "chatMaxSentences", value: e.target.value })}
-                  placeholder="2 (既定)"
-                />
+                <div className="slider-control">
+                  <input
+                    className="range-input"
+                    type="range"
+                    min={1}
+                    max={6}
+                    step={1}
+                    value={resolvedChatMaxSentencesValue}
+                    onChange={(e) => dispatch({ type: "update", field: "chatMaxSentences", value: e.target.value })}
+                  />
+                  <span className="slider-value">{formState.chatMaxSentences || "既定 (2)"}</span>
+                  <button
+                    type="button"
+                    className="slider-reset"
+                    onClick={() => dispatch({ type: "update", field: "chatMaxSentences", value: "" })}
+                    disabled={formState.chatMaxSentences === ""}
+                  >
+                    クリア
+                  </button>
+                </div>
                 <div className="hint">1〜6 の範囲で設定できます。空欄なら既定値 2 を利用します。</div>
               </label>
             </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -68,4 +68,22 @@ details.advanced summary:focus-visible{outline:2px solid var(--brand);outline-of
 .participant-empty-add{background:transparent;border:1px solid var(--border);color:var(--text);border-radius:8px;padding:8px 14px;cursor:pointer}
 .participant-empty-add:hover{border-color:var(--text)}
 .participant-preview{display:inline-block;margin-left:4px;padding:2px 6px;border-radius:6px;border:1px solid var(--border);background:#0d0e13;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:12px}
+.slider-control{display:flex;align-items:center;gap:12px;margin-top:8px}
+.range-input{flex:1 1 auto;min-width:0}
+input[type="range"]{appearance:none;width:100%;background:transparent;height:24px}
+input[type="range"]::-webkit-slider-runnable-track{height:6px;border-radius:999px;background:linear-gradient(90deg,rgba(91,141,239,.85),rgba(91,141,239,.4));transition:background .2s ease}
+input[type="range"]:hover::-webkit-slider-runnable-track{background:linear-gradient(90deg,rgba(91,141,239,1),rgba(91,141,239,.55))}
+input[type="range"]::-webkit-slider-thumb{appearance:none;width:18px;height:18px;border-radius:50%;background:#fff;border:2px solid #5b8def;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease;margin-top:-6px}
+input[type="range"]:hover::-webkit-slider-thumb{transform:scale(1.05)}
+input[type="range"]:focus-visible{outline:none}
+input[type="range"]:focus-visible::-webkit-slider-thumb{box-shadow:0 0 0 4px rgba(91,141,239,.35)}
+input[type="range"]::-moz-range-track{height:6px;border-radius:999px;background:linear-gradient(90deg,rgba(91,141,239,.85),rgba(91,141,239,.4));transition:background .2s ease}
+input[type="range"]:hover::-moz-range-track{background:linear-gradient(90deg,rgba(91,141,239,1),rgba(91,141,239,.55))}
+input[type="range"]::-moz-range-thumb{width:18px;height:18px;border-radius:50%;background:#fff;border:2px solid #5b8def;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease}
+input[type="range"]:hover::-moz-range-thumb{transform:scale(1.05)}
+input[type="range"]:focus-visible::-moz-range-thumb{box-shadow:0 0 0 4px rgba(91,141,239,.35)}
+.slider-value{min-width:70px;font-size:14px;font-weight:600;color:var(--text);text-align:center}
+.slider-reset{background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:8px;padding:6px 10px;font-size:12px;cursor:pointer}
+.slider-reset:hover:not(:disabled){color:var(--text);border-color:var(--text)}
+.slider-reset:disabled{opacity:.5;cursor:not-allowed}
 @media (max-width:900px){.grid-2{grid-template-columns:1fr}}


### PR DESCRIPTION
## Summary
- replace number inputs on the home page with slider controls for precision, rounds, max phases, and chat sentence limits
- surface the live values beside each slider and provide reset actions for optional fields
- style the new range inputs and helper elements to match the existing theme

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68e1424e1a7c832c8b969086e36b4b3a