### PR TITLE
フロントエンドのラウンド表記をフェーズに統一

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -317,7 +317,7 @@ export default function Home() {
             </div>
           </label>
           <label className="label">
-            ラウンド数
+            フェーズターン上限（簡易設定）
             <div className="slider-control">
               <input
                 className="range-input"

--- a/frontend/src/pages/Meeting.jsx
+++ b/frontend/src/pages/Meeting.jsx
@@ -141,7 +141,7 @@ export default function Meeting() {
           {resultReady
             ? "バックエンドから受け取った最終要約です。"
             : summary
-              ? "バックエンド計算の最新ラウンド要約です。"
+              ? "バックエンド計算の最新フェーズ要約です。"
               : "要約算出を待機中です。"}
         </div>
         <div className="hint">


### PR DESCRIPTION
## Summary
- ホーム画面のスライダー表記をフェーズターン上限の案内に変更しました
- 会議画面の要約ヒントからラウンド表記を排除してフェーズ要約と表現しました

## Testing
- npm test *(vitest が未インストールで失敗し、registry へのアクセス権限がなく導入できませんでした)*

------
https://chatgpt.com/codex/tasks/task_e_68e157f3795c832ca9fa1463c384ed94