### PR TITLE
Enable monitor by default and adjust CLI flags

### DIFF
--- a/backend/ai_meeting/cli.py
+++ b/backend/ai_meeting/cli.py
@@ -119,8 +119,16 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     # Step 4
     ap.add_argument(
         "--monitor",
+        dest="monitor",
         action="store_true",
+        default=None,
         help="監視AI（フェーズ自動判定）を有効化（裏方のみ）",
+    )
+    ap.add_argument(
+        "--no-monitor",
+        dest="monitor",
+        action="store_false",
+        help="監視AI（フェーズ自動判定）を無効化",
     )
     ap.add_argument("--phase-window", type=int, default=8)
     ap.add_argument("--phase-cohesion-min", type=float, default=0.70)
@@ -234,6 +242,9 @@ def build_meeting_config(args: argparse.Namespace) -> MeetingConfig:
 
     agent_memory_limit_default = MeetingConfig.model_fields["agent_memory_limit"].default
     agent_memory_window_default = MeetingConfig.model_fields["agent_memory_window"].default
+    monitor_default = MeetingConfig.model_fields["monitor"].default
+    monitor_arg = getattr(args, "monitor", None)
+    monitor_value = monitor_default if monitor_arg is None else bool(monitor_arg)
 
     cfg = MeetingConfig(
         topic=args.topic,
@@ -259,7 +270,7 @@ def build_meeting_config(args: argparse.Namespace) -> MeetingConfig:
         else agent_memory_window_default,
         outdir=getattr(args, "outdir", None),
         equilibrium=getattr(args, "equilibrium", False),
-        monitor=getattr(args, "monitor", False),
+        monitor=monitor_value,
         shock=getattr(args, "shock", "off"),
         shock_ttl=max(1, int(getattr(args, "shock_ttl", 2))),
         ui_minimal=getattr(args, "ui_minimal", True),

--- a/backend/ai_meeting/config.py
+++ b/backend/ai_meeting/config.py
@@ -64,7 +64,7 @@ class MeetingConfig(BaseModel):
     chat_context_summary: bool = True  # サマリーをチャット文脈に注入するか
     # --- 以降のステップ用プレースホルダ（Step 0では未使用） ---
     equilibrium: bool = False  # 均衡AI（メタ評価）
-    monitor: bool = False  # 監視AI（フェーズ検知）
+    monitor: bool = True  # 監視AI（フェーズ検知）
     shock: Literal["off", "random", "explore", "exploit"] = "off"  # ショック注入モード
     shock_ttl: int = 2  # ショックを維持するターン数（フェーズ確定後の有効ターン）
     # --- Step 1: UI最小化（台本感を消す表示） ---

--- a/backend/tests/test_phase_init.py
+++ b/backend/tests/test_phase_init.py
@@ -1,7 +1,16 @@
 """フェーズ初期化に関するテスト。"""
 
+from pathlib import Path
+import sys
+
 import pytest
 
+# `backend` パッケージをインポートできるよう、リポジトリルートをパスに追加する。
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from backend.ai_meeting.cli import build_meeting_config, parse_args
 from backend.ai_meeting.config import AgentConfig, MeetingConfig
 from backend.ai_meeting.meeting import Meeting
 
@@ -28,3 +37,43 @@ def test_meeting_initial_phase_safe(tmp_path, monkeypatch, backend_name):
 
     assert meeting._phase_state is not None
     assert meeting._phase_state.kind == "discussion"
+
+
+def test_meeting_monitor_enabled_by_default(tmp_path, monkeypatch):
+    """監視AIが既定で有効になり Meeting._monitor が初期化されることを検証する。"""
+
+    monkeypatch.setenv("AI_MEETING_TEST_MODE", "deterministic")
+    outdir = tmp_path / "monitor_default"
+    cfg = MeetingConfig(
+        topic="モニター既定値テスト",
+        precision=5,
+        agents=[
+            AgentConfig(name="Alice", system="あなたは会議参加者です。"),
+            AgentConfig(name="Bob", system="あなたは会議参加者です。"),
+        ],
+        backend_name="ollama",
+        outdir=str(outdir),
+    )
+
+    assert cfg.monitor is True
+
+    meeting = Meeting(cfg)
+
+    assert meeting._monitor is not None
+
+
+def test_cli_monitor_flags(monkeypatch):
+    """CLI の --monitor/--no-monitor フラグが既定値と上書きを適切に扱う。"""
+
+    monkeypatch.setenv("AI_MEETING_TEST_MODE", "deterministic")
+
+    base_args = ["--topic", "CLI モニター既定", "--agents", "Alice", "Bob"]
+
+    cfg_default = build_meeting_config(parse_args(base_args))
+    assert cfg_default.monitor is True
+
+    cfg_disabled = build_meeting_config(parse_args(base_args + ["--no-monitor"]))
+    assert cfg_disabled.monitor is False
+
+    cfg_enabled = build_meeting_config(parse_args(base_args + ["--monitor"]))
+    assert cfg_enabled.monitor is True

--- a/docs/meeting_customization.md
+++ b/docs/meeting_customization.md
@@ -59,7 +59,7 @@
 | `--summary-probe-log` | 要約プローブのターンごとの JSONL 出力。 | `False` | `summary_probe_enabled` と併用推奨。 |
 | `--summary-probe-filename` | 要約プローブ出力ファイル名。 | `summary_probe.json` | `summary_probe_enabled` 時のみ利用。 |
 | `--equilibrium` | 均衡 AI (メタ評価) を有効化。 | `False` | Step 0 では未使用。将来機能。 |
-| `--monitor` | フェーズ自動判定 AI。 | `False` | 背景処理のみ。UI では「実験的」ラベル。 |
+| `--monitor` / `--no-monitor` | フェーズ自動判定 AI。 | `True` | 既定で有効。`--no-monitor` で無効化。背景処理のみ。UI では「実験的」ラベル。 |
 
 ## 各設定項目の詳細
 


### PR DESCRIPTION
## Summary
- enable the monitoring controller by default in `MeetingConfig` and update CLI handling to respect the configuration default
- extend phase initialization tests to cover the default monitor behavior and new CLI flags
- document that monitoring is enabled by default and can be disabled with `--no-monitor`

## Testing
- pytest backend/tests/test_phase_init.py

------
https://chatgpt.com/codex/tasks/task_e_68e500d651b0832c9cf2b63e6fccc79b