### PR TITLE
Add meeting stop API integration and tests

### DIFF
--- a/frontend/src/pages/__tests__/Meeting.test.jsx
+++ b/frontend/src/pages/__tests__/Meeting.test.jsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import Meeting from "../Meeting.jsx";
+import * as api from "../../services/api";
+
+const baseSnapshot = {
+  timeline: [],
+  summary: "",
+  kpi: null,
+  progress: null,
+  resultReady: false,
+  final: "",
+  topic: "",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Meeting", () => {
+  it("中止操作が成功すると stopMeeting を呼んでトップページへ遷移する", async () => {
+    vi.spyOn(api, "getLiveSnapshot").mockResolvedValue(baseSnapshot);
+    const stopMock = vi.spyOn(api, "stopMeeting").mockResolvedValue();
+
+    const { container, unmount } = await renderMeeting();
+
+    const cancelButton = getButtonByText(container, "中止して戻る");
+    expect(cancelButton).not.toBeNull();
+
+    await clickButton(cancelButton);
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(stopMock).toHaveBeenCalledWith("sample-meeting");
+    expect(container.querySelector('[data-testid="home"]')).not.toBeNull();
+
+    unmount();
+  });
+
+  it("中止操作が失敗するとエラーメッセージを通知しページに留まる", async () => {
+    vi.spyOn(api, "getLiveSnapshot").mockResolvedValue(baseSnapshot);
+    const stopMock = vi.spyOn(api, "stopMeeting").mockRejectedValue(new Error("停止に失敗しました"));
+    const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    const { container, unmount } = await renderMeeting();
+
+    const cancelButton = getButtonByText(container, "中止して戻る");
+    expect(cancelButton).not.toBeNull();
+
+    await clickButton(cancelButton);
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(stopMock).toHaveBeenCalledWith("sample-meeting");
+    expect(alertMock).toHaveBeenCalledWith("停止に失敗しました");
+    expect(container.querySelector('[data-testid="home"]')).toBeNull();
+    expect(cancelButton?.disabled).toBe(false);
+
+    unmount();
+  });
+});
+
+async function renderMeeting() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={["/meeting/sample-meeting"]}>
+        <Routes>
+          <Route path="/" element={<div data-testid="home">ホーム</div>} />
+          <Route path="/meeting/:id" element={<Meeting />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  });
+
+  await flushEffects();
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function clickButton(button) {
+  if (!button) return;
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flushEffects();
+}
+
+function getButtonByText(container, text) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (btn) => btn.textContent && btn.textContent.trim() === text,
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -183,6 +183,27 @@ function normalizeFilePath(path, meetingId) {
   return `/logs/${meetingId}/${path}`;
 }
 
+export async function stopMeeting(meetingId) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new DOMException("Request timed out", "AbortError"));
+  }, 15000);
+
+  try {
+    const res = await fetch(`/api/meetings/${encodeURIComponent(meetingId)}/stop`, {
+      method: "POST",
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => "");
+      const reason = txt.trim();
+      throw new Error(`stop meeting failed: ${res.status}${reason ? ` ${reason}` : ""}`);
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 export async function startMeeting(payload) {
   const res = await fetch("/api/meetings", {
     method: "POST",


### PR DESCRIPTION
## Summary
- add a stopMeeting API client that posts to the stop endpoint with timeout handling
- update the meeting page cancel button to await stopMeeting, show errors, and only navigate after success
- add Meeting page tests that mock stopMeeting and validate the navigation logic

## Testing
- npm test *(fails: vitest CLI not available because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5414d5528832c9c13026ed85c0ac6