### PR TITLE
Expose log folder identifiers in meeting data

### DIFF
--- a/frontend/src/pages/Ongoing.jsx
+++ b/frontend/src/pages/Ongoing.jsx
@@ -79,7 +79,7 @@ export default function Ongoing() {
       const entries = await Promise.all(
         validMeetings.map(async (meeting) => {
           try {
-            const detail = await getMeetingStatusDetail(meeting.id);
+            const detail = await getMeetingStatusDetail(meeting.id, meeting.log_id);
             return [meeting.id, detail];
           } catch (_) {
             return [meeting.id, {
@@ -182,8 +182,11 @@ export default function Ongoing() {
           const summaryTextRaw = typeof status.summary === "string" ? status.summary.trim() : "";
           const summaryText = summaryTextRaw || "サマリーはまだありません。";
           const summaryClassName = `meeting-list__summary${summaryTextRaw ? "" : " meeting-list__summary--empty"}`;
-          const meetingUrl = `/meeting/${encodeURIComponent(meeting.id)}`;
-          const resultUrl = `/result/${encodeURIComponent(meeting.id)}`;
+          const preferredId = typeof meeting.log_id === "string" && meeting.log_id.trim().length > 0
+            ? meeting.log_id.trim()
+            : meeting.id;
+          const meetingUrl = `/meeting/${encodeURIComponent(preferredId)}`;
+          const resultUrl = `/result/${encodeURIComponent(preferredId)}`;
           const isStopping = Boolean(stoppingMap[meeting.id]);
           return (
             <li key={meeting.id} className="meeting-list__item">

--- a/frontend/src/pages/__tests__/Ongoing.test.jsx
+++ b/frontend/src/pages/__tests__/Ongoing.test.jsx
@@ -14,6 +14,7 @@ describe("Ongoing", () => {
     const meetings = [
       {
         id: "20240101-000000_12345",
+        log_id: "20240101-000000_test-topic",
         topic: "テスト会議",
         backend: "ollama",
         started_at: "20240102-030405",
@@ -40,6 +41,7 @@ describe("Ongoing", () => {
 
     expect(listMock).toHaveBeenCalledTimes(1);
     expect(statusMock).toHaveBeenCalledTimes(1);
+    expect(statusMock).toHaveBeenCalledWith("20240101-000000_12345", "20240101-000000_test-topic");
     expect(container.textContent).toContain("テスト会議");
     expect(container.textContent).toContain("2024-01-02 03:04:05");
     expect(container.textContent).toContain("これは最新サマリーです。");
@@ -52,10 +54,10 @@ describe("Ongoing", () => {
     expect(resultBadge).not.toBeNull();
     expect(resultBadge?.textContent).toContain("結果あり");
 
-    const link = container.querySelector('a[href="/meeting/20240101-000000_12345"]');
+    const link = container.querySelector('a[href="/meeting/20240101-000000_test-topic"]');
     expect(link).not.toBeNull();
 
-    const resultLink = container.querySelector('a[href="/result/20240101-000000_12345"]');
+    const resultLink = container.querySelector('a[href="/result/20240101-000000_test-topic"]');
     expect(resultLink).not.toBeNull();
     expect(resultLink?.textContent).toContain("結果を見る");
 
@@ -91,6 +93,9 @@ describe("Ongoing", () => {
     expect(statusMock).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("部分的な結果");
     expect(container.textContent).toContain("最終出力を生成中です。");
+
+    const fallbackLink = container.querySelector('a[href="/meeting/20240101-000000_67890"]');
+    expect(fallbackLink).not.toBeNull();
 
     const resultBadge = container.querySelector(".meeting-status-badge--pending");
     expect(resultBadge).not.toBeNull();


### PR DESCRIPTION
## Summary
- derive URL-safe log directory identifiers from meeting outdirs and attach them to the meeting APIs
- retain the new log_id/outdir fields on the frontend and use log_id for live snapshot polling
- update the ongoing meetings page and tests to build meeting/result links from log_id with meeting.id as a fallback

## Testing
- npm test -- src/pages/__tests__/Ongoing.test.jsx *(fails: vitest executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c70641f0832c8b5437bfbed0951c